### PR TITLE
Actor seam: identity's minimal core (RFD 0014)

### DIFF
--- a/crates/spock-lang/src/ast.rs
+++ b/crates/spock-lang/src/ast.rs
@@ -96,13 +96,16 @@ pub struct SetMember {
 pub enum DefaultExpr {
     Auto(Span),
     Now(Span),
+    /// `= me` — the current actor (RFD 0014). Legal only on a reference to
+    /// the `auth`-anchored table; the checker enforces the rest.
+    Me(Span),
     Lit(Lit),
 }
 
 impl DefaultExpr {
     pub fn span(&self) -> Span {
         match self {
-            DefaultExpr::Auto(s) | DefaultExpr::Now(s) => *s,
+            DefaultExpr::Auto(s) | DefaultExpr::Now(s) | DefaultExpr::Me(s) => *s,
             DefaultExpr::Lit(lit) => lit.span(),
         }
     }

--- a/crates/spock-lang/src/ast.rs
+++ b/crates/spock-lang/src/ast.rs
@@ -20,6 +20,9 @@ pub struct File {
 pub struct TableDecl {
     pub name: Ident,
     pub items: Vec<TableItem>,
+    /// `auth table ...` — the identity anchor (RFD 0014). `Some(span)` marks
+    /// the `auth` modifier's span (for E-ACT01); `None` is an ordinary table.
+    pub auth: Option<Span>,
     pub span: Span,
 }
 

--- a/crates/spock-lang/src/check.rs
+++ b/crates/spock-lang/src/check.rs
@@ -468,10 +468,7 @@ impl Checker {
                             );
                             continue;
                         }
-                        if matches!(
-                            field.default,
-                            Some(DefaultValue::Auto | DefaultValue::Now | DefaultValue::Actor)
-                        ) {
+                        if field.default.as_ref().is_some_and(DefaultValue::is_engine_minted) {
                             self.error(
                                 "E042",
                                 format!("`check` on `{}`, which is defaulted `auto`/`now`/`me` — an engine-minted value cannot be proven against a validator", f.name.name),
@@ -1022,14 +1019,17 @@ impl Checker {
         // exist. Uses the table's span; the field is named in the message.
         for table in tables {
             for field in &table.fields {
-                if !matches!(field.default, Some(DefaultValue::Actor)) {
+                if !field.is_actor_default() {
                     continue;
                 }
+                // Phase A only lowers `= me` to Actor on a ref, so `target` is
+                // always `Some`; when no anchor is declared `anchor_name` is
+                // `None`, and `Some != None` already fires.
                 let target = match &field.ty {
                     Type::Ref { table, .. } => Some(table.as_str()),
                     _ => None,
                 };
-                if anchor_name.is_none() || target != anchor_name {
+                if target != anchor_name {
                     self.error(
                         "E047",
                         format!(
@@ -1054,20 +1054,13 @@ impl Checker {
             );
         }
         // E046: the first anchor's key must be a single scalar builtin column.
+        // `single_key()` already returns None for a composite key, and a
+        // scalar is anything but a reference or a set.
         if let Some(decl) = anchors.first() {
             if let Some(table) = tables.iter().find(|t| t.name == decl.name.name) {
-                let scalar_single = table.key.len() == 1
-                    && table.single_key().is_some_and(|f| {
-                        matches!(
-                            f.ty,
-                            Type::Text
-                                | Type::Int
-                                | Type::Float
-                                | Type::Bool
-                                | Type::Timestamp
-                                | Type::Uuid
-                        )
-                    });
+                let scalar_single = table
+                    .single_key()
+                    .is_some_and(|f| !matches!(f.ty, Type::Ref { .. } | Type::Set { .. }));
                 if !scalar_single {
                     self.error(
                         "E046",
@@ -1167,8 +1160,7 @@ impl Checker {
                 // seed runs before any actor exists (anonymous), so the
                 // runtime cannot stamp it — the seed row must name it.
                 for field in &table.fields {
-                    let no_seed_default = field.default.is_none()
-                        || matches!(field.default, Some(DefaultValue::Actor));
+                    let no_seed_default = field.default.is_none() || field.is_actor_default();
                     if !field.optional && no_seed_default && !provided.contains(&field.name) {
                         self.error(
                             "E022",
@@ -1607,9 +1599,8 @@ fn derive_errors(table: &Table, all: &[Table]) -> Vec<DerivedError> {
         // field (RFD 0014) is the exception even as a key: an anonymous
         // insert cannot supply it, so the required error is reachable and
         // the floor routes anonymous writes to it (§14.4).
-        let reachable = field.default.is_none()
-            || matches!(field.default, Some(DefaultValue::Actor))
-            || !table.key.contains(&field.name);
+        let reachable =
+            field.default.is_none() || field.is_actor_default() || !table.key.contains(&field.name);
         if !field.optional && reachable {
             errors.push(DerivedError {
                 code: format!("{t}_{}_required", field.name),

--- a/crates/spock-lang/src/check.rs
+++ b/crates/spock-lang/src/check.rs
@@ -161,28 +161,40 @@ impl Checker {
                 if f.is_key {
                     self.error(
                         "E033",
-                        format!("`key` on record field `{}` (records have no keys)", f.name.name),
+                        format!(
+                            "`key` on record field `{}` (records have no keys)",
+                            f.name.name
+                        ),
                         f.name.span,
                     );
                 }
                 if f.unique {
                     self.error(
                         "E033",
-                        format!("`unique` on record field `{}` (records are not stored)", f.name.name),
+                        format!(
+                            "`unique` on record field `{}` (records are not stored)",
+                            f.name.name
+                        ),
                         f.name.span,
                     );
                 }
                 if let Some(d) = &f.default {
                     self.error(
                         "E033",
-                        format!("default on record field `{}` (records are read shapes)", f.name.name),
+                        format!(
+                            "default on record field `{}` (records are read shapes)",
+                            f.name.name
+                        ),
                         d.span(),
                     );
                 }
                 if let Some(c) = &f.on_delete {
                     self.error(
                         "E033",
-                        format!("`on delete` on record field `{}` (records hold no references)", f.name.name),
+                        format!(
+                            "`on delete` on record field `{}` (records hold no references)",
+                            f.name.name
+                        ),
                         c.span,
                     );
                 }
@@ -468,7 +480,11 @@ impl Checker {
                             );
                             continue;
                         }
-                        if field.default.as_ref().is_some_and(DefaultValue::is_engine_minted) {
+                        if field
+                            .default
+                            .as_ref()
+                            .is_some_and(DefaultValue::is_engine_minted)
+                        {
                             self.error(
                                 "E042",
                                 format!("`check` on `{}`, which is defaulted `auto`/`now`/`me` — an engine-minted value cannot be proven against a validator", f.name.name),
@@ -479,7 +495,9 @@ impl Checker {
                         let field_ty = resolve_value_type(&field.ty, tables).clone();
                         self.validate_validator(check, fns, &[field_ty], tables);
                     }
-                    ast::TableItem::Check { fields, fn_name, .. } => {
+                    ast::TableItem::Check {
+                        fields, fn_name, ..
+                    } => {
                         // the group was already validated (fields exist) in
                         // lower_table; resolve each field's value type
                         let mut expected: Vec<Type> = Vec::new();
@@ -527,7 +545,9 @@ impl Checker {
         if !f.readonly {
             self.error(
                 "E042",
-                format!("validator `{name}` is a `mut fn`; a validator must be an unmarked (read) fn"),
+                format!(
+                    "validator `{name}` is a `mut fn`; a validator must be an unmarked (read) fn"
+                ),
                 span,
             );
         }
@@ -741,7 +761,7 @@ impl Checker {
             uniques,
             checks,
             anchor: decl.auth.is_some(), // RFD 0014; E-ACT01/E-ACT02 in phase B
-            errors: Vec::new(), // filled in phase B
+            errors: Vec::new(),          // filled in phase B
         })
     }
 
@@ -907,7 +927,10 @@ impl Checker {
             } else if !seen.insert(m.value.as_str()) {
                 self.error(
                     "E043",
-                    format!("closed-set type of `{field}` repeats the value `{}`", m.value),
+                    format!(
+                        "closed-set type of `{field}` repeats the value `{}`",
+                        m.value
+                    ),
                     m.span,
                 );
             }
@@ -1036,10 +1059,7 @@ impl Checker {
                             "`= me` on `{}.{}` must reference the `auth` table",
                             table.name, field.name
                         ),
-                        spans
-                            .get(&table.name)
-                            .copied()
-                            .unwrap_or(Span::new(0, 0)),
+                        spans.get(&table.name).copied().unwrap_or(Span::new(0, 0)),
                     );
                 }
             }
@@ -1048,8 +1068,7 @@ impl Checker {
         for extra in anchors.iter().skip(1) {
             self.error(
                 "E045",
-                "more than one `auth table`: the actor space has one identity table"
-                    .to_string(),
+                "more than one `auth table`: the actor space has one identity table".to_string(),
                 extra.auth.expect("filtered to auth tables"),
             );
         }
@@ -1798,10 +1817,7 @@ mod tests {
             ["E043"]
         );
         // E043: a set may not be a key (keeps sets off the value_type-via-ref path)
-        assert_eq!(
-            codes("table t { key s: \"a\" | \"b\" }"),
-            ["E043"]
-        );
+        assert_eq!(codes("table t { key s: \"a\" | \"b\" }"), ["E043"]);
         // E009: a default must be a member
         assert_eq!(
             codes("table t { key id: uuid = auto\n s: \"a\" | \"b\" = \"c\" }"),
@@ -1813,13 +1829,12 @@ mod tests {
             ["E023"]
         );
         // L-B: a set may not be a record field (E034) or a fn param (E036)
+        assert_eq!(codes("record r { s: \"a\" | \"b\" }"), ["E034"]);
         assert_eq!(
-            codes("record r { s: \"a\" | \"b\" }"),
-            ["E034"]
-        );
-        assert_eq!(
-            codes("table t { key id: uuid = auto\n n: int }\n\
-                   fn f(s: \"a\" | \"b\") -> t { unchecked sql(\"SELECT 1\") }"),
+            codes(
+                "table t { key id: uuid = auto\n n: int }\n\
+                   fn f(s: \"a\" | \"b\") -> t { unchecked sql(\"SELECT 1\") }"
+            ),
             ["E036"]
         );
     }
@@ -1846,13 +1861,20 @@ mod tests {
             .error_for(ErrorKind::Invalid, &["follower", "target"])
             .is_some());
         assert_eq!(
-            contract.table("user").unwrap().field("username").unwrap().check.as_deref(),
+            contract
+                .table("user")
+                .unwrap()
+                .field("username")
+                .unwrap()
+                .check
+                .as_deref(),
             Some("nonempty")
         );
     }
 
     // a well-formed validator, reused by the law tests below
-    const NONEMPTY: &str = "fn nonempty(s: text) -> bool { unchecked sql(\"SELECT length(:s) > 0\") }\n";
+    const NONEMPTY: &str =
+        "fn nonempty(s: text) -> bool { unchecked sql(\"SELECT length(:s) > 0\") }\n";
 
     #[test]
     fn validator_law_violations() {
@@ -1863,37 +1885,49 @@ mod tests {
         );
         // E042: a `mut fn` is not a validator
         assert_eq!(
-            codes("mut fn v(s: text) -> bool { unchecked sql(\"SELECT length(:s) > 0\") }\n\
-                   table t { key id: uuid = auto\n s: text check v }"),
+            codes(
+                "mut fn v(s: text) -> bool { unchecked sql(\"SELECT length(:s) > 0\") }\n\
+                   table t { key id: uuid = auto\n s: text check v }"
+            ),
             ["E042"]
         );
         // E042: a validator must return bool
         assert_eq!(
-            codes("fn v(s: text) -> int { unchecked sql(\"SELECT length(:s)\") }\n\
-                   table t { key id: uuid = auto\n s: text check v }"),
+            codes(
+                "fn v(s: text) -> int { unchecked sql(\"SELECT length(:s)\") }\n\
+                   table t { key id: uuid = auto\n s: text check v }"
+            ),
             ["E042"]
         );
         // E042: a WHERE clause cannot inline into a CHECK (L-K)
         assert_eq!(
-            codes("fn v(s: text) -> bool { unchecked sql(\"SELECT 1 WHERE length(:s) > 0\") }\n\
-                   table t { key id: uuid = auto\n s: text check v }"),
+            codes(
+                "fn v(s: text) -> bool { unchecked sql(\"SELECT 1 WHERE length(:s) > 0\") }\n\
+                   table t { key id: uuid = auto\n s: text check v }"
+            ),
             ["E042"]
         );
         // E042: a non-deterministic function cannot live in a CHECK (L-N)
         assert_eq!(
-            codes("fn v(s: text) -> bool { unchecked sql(\"SELECT :s > spock_now()\") }\n\
-                   table t { key id: uuid = auto\n s: text check v }"),
+            codes(
+                "fn v(s: text) -> bool { unchecked sql(\"SELECT :s > spock_now()\") }\n\
+                   table t { key id: uuid = auto\n s: text check v }"
+            ),
             ["E042"]
         );
         // E042: param type must match the field's value type
         assert_eq!(
-            codes("fn v(n: int) -> bool { unchecked sql(\"SELECT :n > 0\") }\n\
-                   table t { key id: uuid = auto\n s: text check v }"),
+            codes(
+                "fn v(n: int) -> bool { unchecked sql(\"SELECT :n > 0\") }\n\
+                   table t { key id: uuid = auto\n s: text check v }"
+            ),
             ["E042"]
         );
         // E042: a check may not attach to a set-typed field
         assert_eq!(
-            codes(&format!("{NONEMPTY}table t {{ key id: uuid = auto\n s: \"a\" | \"b\" check nonempty }}")),
+            codes(&format!(
+                "{NONEMPTY}table t {{ key id: uuid = auto\n s: \"a\" | \"b\" check nonempty }}"
+            )),
             ["E042"]
         );
         // E042: a check may not attach to an auto/now-defaulted field
@@ -1903,8 +1937,10 @@ mod tests {
         );
         // arity: a field check binds exactly one param
         assert_eq!(
-            codes("fn v(a: uuid, b: uuid) -> bool { unchecked sql(\"SELECT :a <> :b\") }\n\
-                   table t { key id: uuid = auto\n s: text check v }"),
+            codes(
+                "fn v(a: uuid, b: uuid) -> bool { unchecked sql(\"SELECT :a <> :b\") }\n\
+                   table t { key id: uuid = auto\n s: text check v }"
+            ),
             ["E042"]
         );
     }
@@ -2145,7 +2181,10 @@ mod tests {
         let t = contract.table("t").unwrap();
         assert!(matches!(
             &t.field("u").unwrap().ty,
-            Type::Ref { on_delete: OnDelete::SetNull, .. }
+            Type::Ref {
+                on_delete: OnDelete::SetNull,
+                ..
+            }
         ));
         let user = contract.table("user").unwrap();
         assert!(user.error_for(ErrorKind::Restricted, &[]).is_none());
@@ -2295,7 +2334,10 @@ mod tests {
         assert!(matches!(&rename.params[0].ty, Type::Ref { table, .. } if table == "user"));
         assert_eq!(rename.errors, vec!["user_username_taken", "not_found"]);
         assert_eq!(rename.returns.arity, FnArity::One);
-        assert_eq!(contract.fn_def("tally").unwrap().returns.arity, FnArity::Many);
+        assert_eq!(
+            contract.fn_def("tally").unwrap().returns.arity,
+            FnArity::Many
+        );
         // a fn may share a table's name — separate namespaces
         assert!(compile(&format!(
             "{USER}\
@@ -2359,7 +2401,9 @@ mod tests {
     fn e036_bad_param_types() {
         // unknown type
         assert_eq!(
-            codes(&format!("{USER}fn f(x: ghost) -> user {{ unchecked sql(\"S\") }}")),
+            codes(&format!(
+                "{USER}fn f(x: ghost) -> user {{ unchecked sql(\"S\") }}"
+            )),
             vec!["E036"]
         );
         // record as param

--- a/crates/spock-lang/src/check.rs
+++ b/crates/spock-lang/src/check.rs
@@ -59,8 +59,9 @@ impl Checker {
         self.check_ref_targets(&tables, &spans, file);
         self.check_key_cycles(&tables, &spans);
         // The identity anchor (RFD 0014): E045 ≤1 `auth table`, E046 its key
-        // is a single scalar column. Cross-table, so it lives here.
-        self.check_anchor(&tables, file);
+        // is a single scalar column, E047 `= me` targets the anchor. Cross-
+        // table, so it lives here.
+        self.check_anchor(&tables, file, &spans);
 
         // Derived errors (§6.1) — needs inbound-ref knowledge, so done last.
         let derived: Vec<Vec<DerivedError>> =
@@ -467,10 +468,13 @@ impl Checker {
                             );
                             continue;
                         }
-                        if matches!(field.default, Some(DefaultValue::Auto | DefaultValue::Now)) {
+                        if matches!(
+                            field.default,
+                            Some(DefaultValue::Auto | DefaultValue::Now | DefaultValue::Actor)
+                        ) {
                             self.error(
                                 "E042",
-                                format!("`check` on `{}`, which is defaulted `auto`/`now` — an engine-minted value cannot be proven against a validator", f.name.name),
+                                format!("`check` on `{}`, which is defaulted `auto`/`now`/`me` — an engine-minted value cannot be proven against a validator", f.name.name),
                                 check.span,
                             );
                             continue;
@@ -839,6 +843,21 @@ impl Checker {
 
         let default = match &f.default {
             None => None,
+            // `= me` (RFD 0014): the current actor. Carve-out to E016 — the
+            // one default legal on a reference. Phase B (`check_anchor`)
+            // verifies the target IS the anchor and an anchor exists (E047).
+            Some(ast::DefaultExpr::Me(span)) => {
+                if is_ref {
+                    Some(DefaultValue::Actor)
+                } else {
+                    self.error(
+                        "E047",
+                        "`= me` requires a reference to the `auth` table".to_string(),
+                        *span,
+                    );
+                    None
+                }
+            }
             Some(expr) => {
                 if is_ref {
                     self.error(
@@ -994,9 +1013,37 @@ impl Checker {
     /// - **E046** — the anchor's key is a single scalar (builtin) column;
     ///   `spock_actor()` returns one value, so a composite / ref / set key
     ///   has no scalar identity.
-    fn check_anchor(&mut self, tables: &[Table], file: &ast::File) {
+    fn check_anchor(&mut self, tables: &[Table], file: &ast::File, spans: &HashMap<String, Span>) {
         let anchors: Vec<&ast::TableDecl> =
             file.tables.iter().filter(|d| d.auth.is_some()).collect();
+        let anchor_name = anchors.first().map(|d| d.name.name.as_str());
+        // E047: a `= me` default (DefaultValue::Actor — Phase A only produced
+        // it for a ref) must reference the *anchor* table, and an anchor must
+        // exist. Uses the table's span; the field is named in the message.
+        for table in tables {
+            for field in &table.fields {
+                if !matches!(field.default, Some(DefaultValue::Actor)) {
+                    continue;
+                }
+                let target = match &field.ty {
+                    Type::Ref { table, .. } => Some(table.as_str()),
+                    _ => None,
+                };
+                if anchor_name.is_none() || target != anchor_name {
+                    self.error(
+                        "E047",
+                        format!(
+                            "`= me` on `{}.{}` must reference the `auth` table",
+                            table.name, field.name
+                        ),
+                        spans
+                            .get(&table.name)
+                            .copied()
+                            .unwrap_or(Span::new(0, 0)),
+                    );
+                }
+            }
+        }
         // E045: reject every anchor past the first.
         for extra in anchors.iter().skip(1) {
             self.error(
@@ -1116,9 +1163,13 @@ impl Checker {
                 }
 
                 // E022: required fields with no default must be present.
+                // A `= me` default (RFD 0014) counts as *no default here*:
+                // seed runs before any actor exists (anonymous), so the
+                // runtime cannot stamp it — the seed row must name it.
                 for field in &table.fields {
-                    if !field.optional && field.default.is_none() && !provided.contains(&field.name)
-                    {
+                    let no_seed_default = field.default.is_none()
+                        || matches!(field.default, Some(DefaultValue::Actor));
+                    if !field.optional && no_seed_default && !provided.contains(&field.name) {
                         self.error(
                             "E022",
                             format!(
@@ -1552,8 +1603,13 @@ fn derive_errors(table: &Table, all: &[Table]) -> Vec<DerivedError> {
         // Every required field that can be absent on insert (no default) or
         // cleared on update (any non-key field). Required key fields with a
         // default stay underived: the default satisfies insert and key
-        // immutability protects update — the error is unreachable.
-        let reachable = field.default.is_none() || !table.key.contains(&field.name);
+        // immutability protects update — the error is unreachable. A `= me`
+        // field (RFD 0014) is the exception even as a key: an anonymous
+        // insert cannot supply it, so the required error is reachable and
+        // the floor routes anonymous writes to it (§14.4).
+        let reachable = field.default.is_none()
+            || matches!(field.default, Some(DefaultValue::Actor))
+            || !table.key.contains(&field.name);
         if !field.optional && reachable {
             errors.push(DerivedError {
                 code: format!("{t}_{}_required", field.name),
@@ -1669,6 +1725,52 @@ mod tests {
         );
         // E046: a composite key has no scalar identity
         assert!(codes("auth table m { key (a, b)\n a: int\n b: int }").contains(&"E046"));
+    }
+
+    #[test]
+    fn me_default_rules() {
+        // `= me` on a reference to the anchor lowers to the Actor default,
+        // and a required non-key `= me` derives its `required` error so the
+        // floor can route anonymous writes to it (§14.4).
+        let c = compile(
+            "auth table user { key id: uuid = auto }\n\
+             table post { key id: uuid = auto\n author: user = me\n caption: text? }",
+        )
+        .unwrap();
+        let author = c.table("post").unwrap().field("author").unwrap();
+        assert!(matches!(author.default, Some(DefaultValue::Actor)));
+        assert!(c
+            .table("post")
+            .unwrap()
+            .error_for(ErrorKind::Required, &["author"])
+            .is_some());
+
+        // E047: `= me` on a non-reference field
+        assert!(codes(
+            "auth table user { key id: uuid = auto }\n\
+             table t { key id: uuid = auto\n name: text = me }"
+        )
+        .contains(&"E047"));
+        // E047: `= me` on a reference to a NON-anchor table
+        assert!(codes(
+            "auth table user { key id: uuid = auto }\n\
+             table team { key id: uuid = auto }\n\
+             table t { key id: uuid = auto\n owner: team = me }"
+        )
+        .contains(&"E047"));
+        // E047: `= me` with no anchor declared at all
+        assert!(codes(
+            "table user { key id: uuid = auto }\n\
+             table post { key id: uuid = auto\n author: user = me }"
+        )
+        .contains(&"E047"));
+        // E022: a seed row must name a `= me` column (anonymous at seed time)
+        assert!(codes(
+            "auth table user { key id: uuid = auto\n username: text unique }\n\
+             table post { key id: uuid = auto\n author: user = me\n caption: text? }\n\
+             seed { maya = user { username: \"maya\" }\n post { caption: \"x\" } }"
+        )
+        .contains(&"E022"));
     }
 
     #[test]

--- a/crates/spock-lang/src/check.rs
+++ b/crates/spock-lang/src/check.rs
@@ -58,6 +58,9 @@ impl Checker {
         // Phase B: cross-table validation (needs every table's key resolved).
         self.check_ref_targets(&tables, &spans, file);
         self.check_key_cycles(&tables, &spans);
+        // The identity anchor (RFD 0014): E045 ≤1 `auth table`, E046 its key
+        // is a single scalar column. Cross-table, so it lives here.
+        self.check_anchor(&tables, file);
 
         // Derived errors (§6.1) — needs inbound-ref knowledge, so done last.
         let derived: Vec<Vec<DerivedError>> =
@@ -736,6 +739,7 @@ impl Checker {
             fields,
             uniques,
             checks,
+            anchor: decl.auth.is_some(), // RFD 0014; E-ACT01/E-ACT02 in phase B
             errors: Vec::new(), // filled in phase B
         })
     }
@@ -980,6 +984,53 @@ impl Checker {
                             );
                         }
                     }
+                }
+            }
+        }
+    }
+
+    /// The identity anchor (RFD 0014, `auth table`):
+    /// - **E045** — at most one anchor: the actor space has one identity table.
+    /// - **E046** — the anchor's key is a single scalar (builtin) column;
+    ///   `spock_actor()` returns one value, so a composite / ref / set key
+    ///   has no scalar identity.
+    fn check_anchor(&mut self, tables: &[Table], file: &ast::File) {
+        let anchors: Vec<&ast::TableDecl> =
+            file.tables.iter().filter(|d| d.auth.is_some()).collect();
+        // E045: reject every anchor past the first.
+        for extra in anchors.iter().skip(1) {
+            self.error(
+                "E045",
+                "more than one `auth table`: the actor space has one identity table"
+                    .to_string(),
+                extra.auth.expect("filtered to auth tables"),
+            );
+        }
+        // E046: the first anchor's key must be a single scalar builtin column.
+        if let Some(decl) = anchors.first() {
+            if let Some(table) = tables.iter().find(|t| t.name == decl.name.name) {
+                let scalar_single = table.key.len() == 1
+                    && table.single_key().is_some_and(|f| {
+                        matches!(
+                            f.ty,
+                            Type::Text
+                                | Type::Int
+                                | Type::Float
+                                | Type::Bool
+                                | Type::Timestamp
+                                | Type::Uuid
+                        )
+                    });
+                if !scalar_single {
+                    self.error(
+                        "E046",
+                        format!(
+                            "`auth table {}` must have a single scalar key column \
+                             (spock_actor() returns one value)",
+                            table.name
+                        ),
+                        decl.auth.expect("anchor has an auth span"),
+                    );
                 }
             }
         }
@@ -1598,6 +1649,26 @@ mod tests {
         assert!(user.error_for(ErrorKind::Restricted, &[]).is_some());
         // username has no default and is required
         assert!(user.error_for(ErrorKind::Required, &["username"]).is_some());
+    }
+
+    #[test]
+    fn auth_table_anchor_rules() {
+        // a uuid single-key anchor: marked in the IR and discoverable
+        let c = compile("auth table user { key id: uuid = auto\n username: text unique }").unwrap();
+        assert!(c.table("user").unwrap().anchor);
+        assert_eq!(c.anchor().map(|t| t.name.as_str()), Some("user"));
+        // a natural single-scalar (text) key is a valid anchor too
+        assert!(compile("auth table account { key handle: text }").is_ok());
+        // E045: at most one anchor
+        assert_eq!(
+            codes(
+                "auth table user { key id: uuid = auto }\n\
+                 auth table admin { key id: uuid = auto }"
+            ),
+            ["E045"]
+        );
+        // E046: a composite key has no scalar identity
+        assert!(codes("auth table m { key (a, b)\n a: int\n b: int }").contains(&"E046"));
     }
 
     #[test]

--- a/crates/spock-lang/src/ddl.rs
+++ b/crates/spock-lang/src/ddl.rs
@@ -431,7 +431,10 @@ mod tests {
             "{user}"
         );
         // the row validator inlines both params positionally
-        let follow = statements.iter().find(|s| s.contains("\"follow\"")).unwrap();
+        let follow = statements
+            .iter()
+            .find(|s| s.contains("\"follow\""))
+            .unwrap();
         assert!(
             follow.contains(
                 "CONSTRAINT \"follow_follower_target_invalid\" CHECK (\"follower\" <> \"target\")"
@@ -481,8 +484,7 @@ mod tests {
 
     #[test]
     fn emits_real_for_float() {
-        let contract =
-            compile("table tag { key id: uuid = auto\n x: float\n y: float? }").unwrap();
+        let contract = compile("table tag { key id: uuid = auto\n x: float\n y: float? }").unwrap();
         let statements = ddl(&contract);
         assert!(statements[0].contains("\"x\" REAL NOT NULL"));
         assert!(statements[0].contains("\"y\" REAL,"));
@@ -500,7 +502,8 @@ mod tests {
         )
         .unwrap();
         let statements = ddl(&contract);
-        assert!(statements[1]
-            .contains("FOREIGN KEY (\"parent\") REFERENCES \"comment\" (\"id\") ON DELETE SET NULL"));
+        assert!(statements[1].contains(
+            "FOREIGN KEY (\"parent\") REFERENCES \"comment\" (\"id\") ON DELETE SET NULL"
+        ));
     }
 }

--- a/crates/spock-lang/src/ddl.rs
+++ b/crates/spock-lang/src/ddl.rs
@@ -20,14 +20,15 @@ pub fn ddl(contract: &Contract) -> Vec<String> {
             for field in &table.fields {
                 let storage = contract.storage_type(&field.ty).sql();
                 let null = if field.optional { "" } else { " NOT NULL" };
-                let default = match &field.default {
-                    // `= me` (RFD 0014) emits NO DDL DEFAULT: spock_actor() is
-                    // DIRECTONLY and cannot sit in a DEFAULT clause. The
-                    // runtime materializes the actor on the write path; an
-                    // escape names spock_actor() itself (§14.3).
-                    None | Some(DefaultValue::Actor) => String::new(),
-                    Some(d) => format!(" DEFAULT {}", default_sql(d)),
-                };
+                // `= me` (RFD 0014) has no DDL DEFAULT — `default_sql` returns
+                // None: spock_actor() is DIRECTONLY, so the runtime stamps the
+                // actor on the write path and an escape names spock_actor().
+                let default = field
+                    .default
+                    .as_ref()
+                    .and_then(default_sql)
+                    .map(|expr| format!(" DEFAULT {expr}"))
+                    .unwrap_or_default();
                 lines.push(format!("  \"{}\" {storage}{null}{default}", field.name));
             }
 
@@ -113,20 +114,20 @@ pub fn ddl(contract: &Contract) -> Vec<String> {
         .collect()
 }
 
-/// A default value as a SQLite DEFAULT expression.
-fn default_sql(default: &DefaultValue) -> String {
-    match default {
+/// A default value as a SQLite DEFAULT expression, or `None` for `= me`
+/// (RFD 0014): `spock_actor()` is DIRECTONLY, so `me` has no DDL DEFAULT —
+/// the runtime materializes it on the write path instead.
+fn default_sql(default: &DefaultValue) -> Option<String> {
+    Some(match default {
         DefaultValue::Auto => "(spock_uuid())".into(),
         DefaultValue::Now => "(spock_now())".into(),
-        // `= me` emits no DEFAULT clause — the call site short-circuits it,
-        // so this is never reached (the actor is materialized at write time).
-        DefaultValue::Actor => unreachable!("`= me` emits no DEFAULT clause"),
+        DefaultValue::Actor => return None,
         DefaultValue::Str { value } => format!("'{}'", value.replace('\'', "''")),
         DefaultValue::Int { value } => value.to_string(),
         // {:?} keeps the decimal point (`2.0`, not `2`) — literals verbatim
         DefaultValue::Float { value } => format!("{value:?}"),
         DefaultValue::Bool { value } => if *value { "1" } else { "0" }.into(),
-    }
+    })
 }
 
 fn quote_list(names: &[String]) -> String {
@@ -216,11 +217,12 @@ pub fn field_check_default_probe(
 ) -> Option<String> {
     let field = contract.table(table_name)?.field(field_name)?;
     let fn_name = field.check.as_ref()?;
-    let value = match field.default.as_ref()? {
-        // engine-minted defaults have no literal to probe against a check
-        DefaultValue::Auto | DefaultValue::Now | DefaultValue::Actor => return None,
-        lit => default_sql(lit),
-    };
+    let d = field.default.as_ref()?;
+    // engine-minted defaults have no literal to probe against a check
+    if d.is_engine_minted() {
+        return None;
+    }
+    let value = default_sql(d)?;
     let f = contract.fn_def(fn_name)?;
     let param = f.params.first()?;
     let map: HashMap<&str, String> = std::iter::once((param.name.as_str(), value)).collect();

--- a/crates/spock-lang/src/ddl.rs
+++ b/crates/spock-lang/src/ddl.rs
@@ -21,7 +21,11 @@ pub fn ddl(contract: &Contract) -> Vec<String> {
                 let storage = contract.storage_type(&field.ty).sql();
                 let null = if field.optional { "" } else { " NOT NULL" };
                 let default = match &field.default {
-                    None => String::new(),
+                    // `= me` (RFD 0014) emits NO DDL DEFAULT: spock_actor() is
+                    // DIRECTONLY and cannot sit in a DEFAULT clause. The
+                    // runtime materializes the actor on the write path; an
+                    // escape names spock_actor() itself (§14.3).
+                    None | Some(DefaultValue::Actor) => String::new(),
                     Some(d) => format!(" DEFAULT {}", default_sql(d)),
                 };
                 lines.push(format!("  \"{}\" {storage}{null}{default}", field.name));
@@ -114,6 +118,9 @@ fn default_sql(default: &DefaultValue) -> String {
     match default {
         DefaultValue::Auto => "(spock_uuid())".into(),
         DefaultValue::Now => "(spock_now())".into(),
+        // `= me` emits no DEFAULT clause — the call site short-circuits it,
+        // so this is never reached (the actor is materialized at write time).
+        DefaultValue::Actor => unreachable!("`= me` emits no DEFAULT clause"),
         DefaultValue::Str { value } => format!("'{}'", value.replace('\'', "''")),
         DefaultValue::Int { value } => value.to_string(),
         // {:?} keeps the decimal point (`2.0`, not `2`) — literals verbatim
@@ -210,7 +217,8 @@ pub fn field_check_default_probe(
     let field = contract.table(table_name)?.field(field_name)?;
     let fn_name = field.check.as_ref()?;
     let value = match field.default.as_ref()? {
-        DefaultValue::Auto | DefaultValue::Now => return None,
+        // engine-minted defaults have no literal to probe against a check
+        DefaultValue::Auto | DefaultValue::Now | DefaultValue::Actor => return None,
         lit => default_sql(lit),
     };
     let f = contract.fn_def(fn_name)?;

--- a/crates/spock-lang/src/ir.rs
+++ b/crates/spock-lang/src/ir.rs
@@ -110,6 +110,11 @@ pub enum DefaultValue {
     Auto,
     /// UTC now captured by the runtime at insert.
     Now,
+    /// The current actor's key, stamped by the runtime at insert (RFD 0014,
+    /// `= me`). A *strong preset*: removed from the client insert/update
+    /// surface, so a client cannot forge it. Runtime-materialized on the
+    /// write path — never a DDL DEFAULT, since `spock_actor()` is DIRECTONLY.
+    Actor,
     Str {
         value: String,
     },

--- a/crates/spock-lang/src/ir.rs
+++ b/crates/spock-lang/src/ir.rs
@@ -66,6 +66,14 @@ pub struct Field {
     pub check: Option<String>,
 }
 
+impl Field {
+    /// A `= me` field (RFD 0014): the current actor, stamped server-side and
+    /// removed from the client insert/update surface.
+    pub fn is_actor_default(&self) -> bool {
+        matches!(self.default, Some(DefaultValue::Actor))
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum Type {
@@ -127,6 +135,18 @@ pub enum DefaultValue {
     Bool {
         value: bool,
     },
+}
+
+impl DefaultValue {
+    /// A default the engine mints at insert (`auto`/`now`/`me`): there is no
+    /// literal to validate against a `check`, and no DDL DEFAULT for `me`
+    /// (RFD 0013/0014).
+    pub fn is_engine_minted(&self) -> bool {
+        matches!(
+            self,
+            DefaultValue::Auto | DefaultValue::Now | DefaultValue::Actor
+        )
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/spock-lang/src/ir.rs
+++ b/crates/spock-lang/src/ir.rs
@@ -35,6 +35,11 @@ pub struct Table {
     /// `spock: "v0"`; parallel to `uniques`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub checks: Vec<TableCheck>,
+    /// The identity anchor (RFD 0014): `true` on the one `auth table`. Its
+    /// single scalar key is what `spock_actor()` returns and `= me` stamps.
+    /// Additive under `spock: "v0"` — `default` keeps pre-actor JSON loading.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub anchor: bool,
     /// Derived errors (§6.1). Never hand-written.
     pub errors: Vec<DerivedError>,
 }
@@ -314,6 +319,13 @@ impl Contract {
         self.fns.iter().find(|f| f.name == name)
     }
 
+    /// The identity anchor table (RFD 0014), if one is declared (`auth
+    /// table`). At most one exists (E-ACT01). `spock_actor()` returns its
+    /// single scalar key (E-ACT02); `= me` stamps it.
+    pub fn anchor(&self) -> Option<&Table> {
+        self.tables.iter().find(|t| t.anchor)
+    }
+
     /// The normalized `(name, type, optional)` field list of a fn output
     /// shape — a table or a record. One lookup shared by engine
     /// validation, execution row mapping, GraphQL, and the TS emission.
@@ -452,6 +464,7 @@ mod tests {
                 ],
                 uniques: vec![],
                 checks: vec![],
+                anchor: false,
                 errors: vec![DerivedError {
                     code: "user_already_exists".into(),
                     kind: ErrorKind::Key,

--- a/crates/spock-lang/src/lexer.rs
+++ b/crates/spock-lang/src/lexer.rs
@@ -322,8 +322,8 @@ pub fn lex(source: &str) -> Result<Vec<Token>, Diagnostic> {
             while i < bytes.len() && bytes[i].is_ascii_digit() {
                 i += 1;
             }
-            let is_float = bytes.get(i) == Some(&b'.')
-                && bytes.get(i + 1).is_some_and(u8::is_ascii_digit);
+            let is_float =
+                bytes.get(i) == Some(&b'.') && bytes.get(i + 1).is_some_and(u8::is_ascii_digit);
             if is_float {
                 i += 1;
                 while i < bytes.len() && bytes[i].is_ascii_digit() {

--- a/crates/spock-lang/src/lexer.rs
+++ b/crates/spock-lang/src/lexer.rs
@@ -27,6 +27,7 @@ pub enum TokenKind {
 
     // active keywords (§2.3)
     KwTable,
+    KwAuth,
     KwRecord,
     KwFn,
     KwMut,
@@ -48,6 +49,7 @@ pub enum TokenKind {
     KwUuid,
     KwAuto,
     KwNow,
+    KwMe,
     KwTrue,
     KwFalse,
 
@@ -84,6 +86,7 @@ impl TokenKind {
 fn keyword_text(kind: &TokenKind) -> &'static str {
     match kind {
         TokenKind::KwTable => "table",
+        TokenKind::KwAuth => "auth",
         TokenKind::KwRecord => "record",
         TokenKind::KwFn => "fn",
         TokenKind::KwMut => "mut",
@@ -105,6 +108,7 @@ fn keyword_text(kind: &TokenKind) -> &'static str {
         TokenKind::KwUuid => "uuid",
         TokenKind::KwAuto => "auto",
         TokenKind::KwNow => "now",
+        TokenKind::KwMe => "me",
         TokenKind::KwTrue => "true",
         TokenKind::KwFalse => "false",
         _ => unreachable!("not a keyword"),
@@ -136,6 +140,7 @@ const RESERVED: &[&str] = &[
 fn keyword(word: &str) -> Option<TokenKind> {
     Some(match word {
         "table" => TokenKind::KwTable,
+        "auth" => TokenKind::KwAuth,
         "record" => TokenKind::KwRecord,
         "fn" => TokenKind::KwFn,
         "mut" => TokenKind::KwMut,
@@ -157,6 +162,7 @@ fn keyword(word: &str) -> Option<TokenKind> {
         "uuid" => TokenKind::KwUuid,
         "auto" => TokenKind::KwAuto,
         "now" => TokenKind::KwNow,
+        "me" => TokenKind::KwMe,
         "true" => TokenKind::KwTrue,
         "false" => TokenKind::KwFalse,
         _ => return None,

--- a/crates/spock-lang/src/parser.rs
+++ b/crates/spock-lang/src/parser.rs
@@ -601,12 +601,13 @@ impl Parser {
         let expr = match &tok.kind {
             TokenKind::KwAuto => DefaultExpr::Auto(tok.span),
             TokenKind::KwNow => DefaultExpr::Now(tok.span),
+            TokenKind::KwMe => DefaultExpr::Me(tok.span),
             TokenKind::Str(s) => DefaultExpr::Lit(Lit::Str(s.clone(), tok.span)),
             TokenKind::Int(v) => DefaultExpr::Lit(Lit::Int(*v, tok.span)),
             TokenKind::Float(v) => DefaultExpr::Lit(Lit::Float(*v, tok.span)),
             TokenKind::KwTrue => DefaultExpr::Lit(Lit::Bool(true, tok.span)),
             TokenKind::KwFalse => DefaultExpr::Lit(Lit::Bool(false, tok.span)),
-            _ => return Err(self.unexpected("`auto`, `now`, or a literal")),
+            _ => return Err(self.unexpected("`auto`, `now`, `me`, or a literal")),
         };
         self.bump();
         Ok(expr)

--- a/crates/spock-lang/src/parser.rs
+++ b/crates/spock-lang/src/parser.rs
@@ -100,9 +100,8 @@ impl Parser {
                 TokenKind::KwSeed => seeds.push(self.seed_block()?),
                 TokenKind::Eof => break,
                 _ => {
-                    return Err(
-                        self.unexpected("`table`, `auth table`, `record`, `fn`, `mut fn`, or `seed`")
-                    );
+                    return Err(self
+                        .unexpected("`table`, `auth table`, `record`, `fn`, `mut fn`, or `seed`"));
                 }
             }
         }
@@ -377,7 +376,10 @@ impl Parser {
                 self.peek().span,
             ));
         }
-        self.expect(TokenKind::Comma, "`,` (a row check names two or more fields)")?;
+        self.expect(
+            TokenKind::Comma,
+            "`,` (a row check names two or more fields)",
+        )?;
         fields.push(self.ident("a field name")?);
         while self.peek().kind == TokenKind::Comma {
             self.bump();
@@ -387,7 +389,8 @@ impl Parser {
         // The validator name is a bare trailing ident with no delimiter, so
         // omitting it would swallow the next field's name — guard the common
         // case (a field line follows) with a message at the group (L-D).
-        if matches!(self.peek().kind, TokenKind::Ident(_)) && self.peek2().kind == TokenKind::Colon {
+        if matches!(self.peek().kind, TokenKind::Ident(_)) && self.peek2().kind == TokenKind::Colon
+        {
             return Err(Diagnostic::new(
                 "L010",
                 "row check is missing its validator fn name: write `check (a, b) fn_name`",
@@ -569,14 +572,20 @@ impl Parser {
         };
         let start = first.span;
         let mut end = first.span;
-        let mut members = vec![SetMember { value, span: first.span }];
+        let mut members = vec![SetMember {
+            value,
+            span: first.span,
+        }];
         while self.peek().kind == TokenKind::Pipe {
             self.bump();
             let tok = self.bump();
             match tok.kind {
                 TokenKind::Str(value) => {
                     end = tok.span;
-                    members.push(SetMember { value, span: tok.span });
+                    members.push(SetMember {
+                        value,
+                        span: tok.span,
+                    });
                 }
                 _ => {
                     return Err(Diagnostic::new(
@@ -781,7 +790,9 @@ mod tests {
         let TableItem::Field(status) = &table.items[2] else {
             panic!("expected field");
         };
-        assert!(matches!(&status.default, Some(DefaultExpr::Lit(Lit::Str(s, _))) if s == "pending"));
+        assert!(
+            matches!(&status.default, Some(DefaultExpr::Lit(Lit::Str(s, _))) if s == "pending")
+        );
         // the singleton case is a *parse*, deferred to the checker (E043)
         let one = parse_ok("table t { key id: uuid = auto\n s: \"only\" }");
         let TableItem::Field(s) = &one.tables[0].items[1] else {
@@ -812,7 +823,10 @@ mod tests {
         };
         assert!(matches!(&username.check, Some(i) if i.name == "valid_username"));
         assert!(username.unique); // check comes before unique
-        let TableItem::Check { fields, fn_name, .. } = &file.tables[1].items[3] else {
+        let TableItem::Check {
+            fields, fn_name, ..
+        } = &file.tables[1].items[3]
+        else {
             panic!("expected a row check");
         };
         assert_eq!(fields.len(), 2);
@@ -831,9 +845,8 @@ mod tests {
         let d = parse_err("table t { key id: uuid = auto\n a: t\n check distinct(a) }");
         assert!(d.message.contains("row check"), "{}", d.message);
         // an omitted validator swallows the next field → targeted message
-        let d = parse_err(
-            "table t { key (a, b)\n a: t\n b: t\n check (a, b)\n c: timestamp = now }",
-        );
+        let d =
+            parse_err("table t { key (a, b)\n a: t\n b: t\n check (a, b)\n c: timestamp = now }");
         assert!(d.message.contains("missing its validator"), "{}", d.message);
         // the misordered `unique check`
         let d = parse_err("table t { key id: uuid = auto\n s: text unique check v }");
@@ -1028,7 +1041,10 @@ mod tests {
     #[test]
     fn rejects_malformed_fns() {
         // missing arrow
-        assert_eq!(parse_err("fn f() user { unchecked sql(\"x\") }").code, "L010");
+        assert_eq!(
+            parse_err("fn f() user { unchecked sql(\"x\") }").code,
+            "L010"
+        );
         // body must open with the marker
         let d = parse_err("fn f() -> t { nosql(\"x\") }");
         assert!(d.message.contains("expected `unchecked`"), "{}", d.message);

--- a/crates/spock-lang/src/parser.rs
+++ b/crates/spock-lang/src/parser.rs
@@ -74,6 +74,18 @@ impl Parser {
         loop {
             match self.peek().kind {
                 TokenKind::KwTable => tables.push(self.table_decl()?),
+                TokenKind::KwAuth => {
+                    // `auth table ...` — the identity anchor (RFD 0014).
+                    // Mirrors the `mut fn` modifier dispatch below.
+                    let start = self.bump().span;
+                    if self.peek().kind != TokenKind::KwTable {
+                        return Err(self.unexpected("`table` (only a table can be `auth`)"));
+                    }
+                    let mut decl = self.table_decl()?;
+                    decl.auth = Some(start);
+                    decl.span = start.to(decl.span);
+                    tables.push(decl);
+                }
                 TokenKind::KwRecord => records.push(self.record_decl()?),
                 TokenKind::KwFn => fns.push(self.fn_decl(false)?),
                 TokenKind::KwMut => {
@@ -88,7 +100,9 @@ impl Parser {
                 TokenKind::KwSeed => seeds.push(self.seed_block()?),
                 TokenKind::Eof => break,
                 _ => {
-                    return Err(self.unexpected("`table`, `record`, `fn`, `mut fn`, or `seed`"));
+                    return Err(
+                        self.unexpected("`table`, `auth table`, `record`, `fn`, `mut fn`, or `seed`")
+                    );
                 }
             }
         }
@@ -116,6 +130,7 @@ impl Parser {
         Ok(TableDecl {
             name,
             items,
+            auth: None,
             span: start.to(end),
         })
     }
@@ -911,6 +926,20 @@ mod tests {
         let d = parse_err("mut table user { key id: uuid = auto }");
         assert_eq!(d.code, "L010");
         assert!(d.message.contains("only a fn"), "{}", d.message);
+    }
+
+    #[test]
+    fn parses_auth_table_anchor() {
+        let file = parse_ok(
+            "auth table user { key id: uuid = auto }\n\
+             table post { key id: uuid = auto }",
+        );
+        assert!(file.tables[0].auth.is_some());
+        assert!(file.tables[1].auth.is_none());
+        // `auth` marks tables only
+        let d = parse_err("auth fn f() -> t { unchecked sql(\"x\") }");
+        assert_eq!(d.code, "L010");
+        assert!(d.message.contains("only a table"), "{}", d.message);
     }
 
     #[test]

--- a/crates/spock-lang/src/typescript.rs
+++ b/crates/spock-lang/src/typescript.rs
@@ -220,7 +220,11 @@ pub fn typescript(contract: &Contract) -> Result<String, TsGenError> {
     out.push_str("\n/** Reserved non-derived codes (docs/spec/v0.md §6.1). */\n");
     out.push_str("export type reserved_error =\n");
     for (i, code) in crate::ir::RESERVED_CODES.iter().enumerate() {
-        let end = if i + 1 == crate::ir::RESERVED_CODES.len() { ";" } else { "" };
+        let end = if i + 1 == crate::ir::RESERVED_CODES.len() {
+            ";"
+        } else {
+            ""
+        };
         let _ = writeln!(out, "  | \"{code}\"{end}");
     }
 
@@ -393,7 +397,11 @@ fn ts_string_lit(s: &str) -> String {
 
 /// `interface <t>` — the row, as reads return it.
 fn emit_row(out: &mut String, contract: &Contract, table: &Table) {
-    let _ = writeln!(out, "\n/** One `{}` row, as reads return it. */", table.name);
+    let _ = writeln!(
+        out,
+        "\n/** One `{}` row, as reads return it. */",
+        table.name
+    );
     let _ = writeln!(out, "export interface {} {{", table.name);
     for f in &table.fields {
         // a checked field carries its validator's name (RFD 0013) — the
@@ -541,7 +549,10 @@ mod tests {
             .skip_while(|l| !l.starts_with("export interface user_update"))
             .take_while(|l| !l.starts_with('}'))
             .collect();
-        assert!(!block.iter().any(|l| l.trim_start().starts_with("id")), "{block:?}");
+        assert!(
+            !block.iter().any(|l| l.trim_start().starts_with("id")),
+            "{block:?}"
+        );
         assert!(block.contains(&"  username?: string;"), "{block:?}"); // no `| null`
         assert!(block.contains(&"  bio?: string | null;"), "{block:?}");
     }
@@ -555,7 +566,9 @@ mod tests {
         assert!(ts.contains("\"follow_already_exists\""), "{ts}");
         assert!(ts.contains("| reserved_error;"), "{ts}");
         assert!(
-            ts.contains("user: { row: user; insert: user_insert; update: user_update; error: user_error };"),
+            ts.contains(
+                "user: { row: user; insert: user_insert; update: user_update; error: user_error };"
+            ),
             "{ts}"
         );
     }
@@ -578,9 +591,15 @@ mod tests {
     fn reserved_table_name_fails_generation() {
         // type-position keywords (`keyof` etc.) would emit non-compiling
         // TS; `reserved` collides through its DERIVED name `reserved_error`
-        for table in ["function", "string", "contract", "keyof", "readonly", "infer", "reserved"] {
-            let err = emit(&format!("table {table} {{ key id: uuid = auto\n a: int }}")).unwrap_err();
-            assert!(matches!(err, TsGenError::ReservedName { .. }), "{table}: {err}");
+        for table in [
+            "function", "string", "contract", "keyof", "readonly", "infer", "reserved",
+        ] {
+            let err =
+                emit(&format!("table {table} {{ key id: uuid = auto\n a: int }}")).unwrap_err();
+            assert!(
+                matches!(err, TsGenError::ReservedName { .. }),
+                "{table}: {err}"
+            );
         }
     }
 
@@ -657,7 +676,12 @@ export interface contract {
         )
         .unwrap();
         // record interface
-        assert!(ts.contains("export interface stats {\n  posts: number;\n  latest: timestamp | null;\n}"), "{ts}");
+        assert!(
+            ts.contains(
+                "export interface stats {\n  posts: number;\n  latest: timestamp | null;\n}"
+            ),
+            "{ts}"
+        );
         // args: required, ref-as-target-key, optional-with-null
         assert!(ts.contains("export interface rename_user_args {\n  user: user[\"id\"];\n  name: string;\n  note?: string | null;\n}"), "{ts}");
         // zero-param fn still gets an (empty) args interface
@@ -681,7 +705,9 @@ export interface contract {
             "{ts}"
         );
         assert!(
-            ts.contains("    tally: { args: tally_args; returns: stats[]; error: never; readonly: true };"),
+            ts.contains(
+                "    tally: { args: tally_args; returns: stats[]; error: never; readonly: true };"
+            ),
             "{ts}"
         );
     }

--- a/crates/spock-lang/src/typescript.rs
+++ b/crates/spock-lang/src/typescript.rs
@@ -16,7 +16,7 @@
 use std::collections::HashMap;
 use std::fmt::Write as _;
 
-use crate::ir::{Contract, DefaultValue, FnArity, FnDef, Record, Table, Type};
+use crate::ir::{Contract, FnArity, FnDef, Record, Table, Type};
 
 /// Names the emission may never assign to a table: JavaScript reserved
 /// words (invalid as type names), TypeScript's predeclared type names,
@@ -421,7 +421,7 @@ fn emit_insert(out: &mut String, contract: &Contract, table: &Table) {
     for f in &table.fields {
         // `= me` fields (RFD 0014) leave the client write surface: the
         // runtime stamps the actor, and the client may not set it.
-        if matches!(f.default, Some(DefaultValue::Actor)) {
+        if f.is_actor_default() {
             continue;
         }
         let ty = value_ts(contract, &f.ty);
@@ -448,7 +448,7 @@ fn emit_update(out: &mut String, contract: &Contract, table: &Table) {
     for f in &table.fields {
         // keys are immutable; `= me` fields are stamped once and never
         // reassigned by a client (RFD 0014) — both leave the update surface.
-        if table.key.contains(&f.name) || matches!(f.default, Some(DefaultValue::Actor)) {
+        if table.key.contains(&f.name) || f.is_actor_default() {
             continue;
         }
         let null = if f.optional { " | null" } else { "" };

--- a/crates/spock-lang/src/typescript.rs
+++ b/crates/spock-lang/src/typescript.rs
@@ -16,7 +16,7 @@
 use std::collections::HashMap;
 use std::fmt::Write as _;
 
-use crate::ir::{Contract, FnArity, FnDef, Record, Table, Type};
+use crate::ir::{Contract, DefaultValue, FnArity, FnDef, Record, Table, Type};
 
 /// Names the emission may never assign to a table: JavaScript reserved
 /// words (invalid as type names), TypeScript's predeclared type names,
@@ -419,6 +419,11 @@ fn emit_insert(out: &mut String, contract: &Contract, table: &Table) {
     );
     let _ = writeln!(out, "export interface {}_insert {{", table.name);
     for f in &table.fields {
+        // `= me` fields (RFD 0014) leave the client write surface: the
+        // runtime stamps the actor, and the client may not set it.
+        if matches!(f.default, Some(DefaultValue::Actor)) {
+            continue;
+        }
         let ty = value_ts(contract, &f.ty);
         if !f.optional && f.default.is_none() {
             let _ = writeln!(out, "  {}: {ty};", f.name);
@@ -441,7 +446,9 @@ fn emit_update(out: &mut String, contract: &Contract, table: &Table) {
     );
     let _ = writeln!(out, "export interface {}_update {{", table.name);
     for f in &table.fields {
-        if table.key.contains(&f.name) {
+        // keys are immutable; `= me` fields are stamped once and never
+        // reassigned by a client (RFD 0014) — both leave the update surface.
+        if table.key.contains(&f.name) || matches!(f.default, Some(DefaultValue::Actor)) {
             continue;
         }
         let null = if f.optional { " | null" } else { "" };

--- a/crates/spock-runtime/src/engine.rs
+++ b/crates/spock-runtime/src/engine.rs
@@ -397,12 +397,15 @@ fn seed(contract: &Contract, conn: &mut Connection) -> Result<(), EngineError> {
             body.insert(name.clone(), json);
         }
 
-        let stored =
-            insert_row(contract, table, conn, &body).map_err(|source| EngineError::Seed {
+        // seed runs before any actor exists (anonymous); a `= me` column
+        // must be named explicitly in the row (checker E022, RFD 0014 §14.4).
+        let stored = insert_row(contract, table, conn, &body, None).map_err(|source| {
+            EngineError::Seed {
                 index,
                 table: table.name.clone(),
                 source: Box::new(source),
-            })?;
+            }
+        })?;
 
         if let Some(binding) = &row.binding {
             if let Some(key_field) = table.key.first() {

--- a/crates/spock-runtime/src/engine.rs
+++ b/crates/spock-runtime/src/engine.rs
@@ -5,6 +5,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+use rusqlite::types::Value as SqlValue;
 use rusqlite::Connection;
 use serde_json::{Map, Value as Json};
 use spock_lang::ddl::ddl;
@@ -54,7 +55,7 @@ pub fn open(contract: &Contract, path: Option<&Path>) -> Result<Connection, Engi
     };
 
     conn.pragma_update(None, "foreign_keys", true)?;
-    register_builtins(&conn)?;
+    register_builtins(contract, &conn)?;
     for statement in ddl(contract) {
         conn.execute_batch(&statement)?;
     }
@@ -105,7 +106,7 @@ pub(crate) const REFUSE_SENTINEL: &str = "SPOCK_REFUSE:";
 /// channel: it always errors when evaluated, so a guard that selects
 /// zero rows never fires it. Registered before DDL: the emitted DEFAULT
 /// clauses reference the mints.
-fn register_builtins(conn: &Connection) -> Result<(), EngineError> {
+fn register_builtins(contract: &Contract, conn: &Connection) -> Result<(), EngineError> {
     use rusqlite::functions::FunctionFlags;
     // non-deterministic by nature: neither DETERMINISTIC (they change per
     // call) nor DIRECTONLY (DEFAULT clauses must be able to call them)
@@ -130,7 +131,33 @@ fn register_builtins(conn: &Connection) -> Result<(), EngineError> {
             ))
         },
     )?;
+    // `spock_actor()` (RFD 0014): the current actor's key, NULL when
+    // anonymous. Registered ONLY when a table is `auth`-marked — so a body
+    // that calls it without an anchor fails at prepare ("no such function"),
+    // which *is* the identity-needs-a-consumer rule (E-ACT03). At load the
+    // value is NULL; `func::call` re-binds it per request (§4.3). DIRECTONLY
+    // like `spock_refuse`, NOT like `spock_now`: the actor is request-scoped
+    // state, correct only inside a `func::call`, never in a DEFAULT/CHECK the
+    // actor-blind floor evaluates (§4.2).
+    if contract.anchor().is_some() {
+        register_actor(conn, None)?;
+    }
     Ok(())
+}
+
+/// Bind `spock_actor()` to `actor` (NULL when anonymous) on `conn`. Called
+/// once at load (NULL) and re-called by `func::call` per request with the
+/// resolved actor — SQLite replaces the same-named function, and the single
+/// serialized connection makes the re-bind race-free (RFD 0014 §4.3).
+pub(crate) fn register_actor(conn: &Connection, actor: Option<SqlValue>) -> rusqlite::Result<()> {
+    use rusqlite::functions::FunctionFlags;
+    let value = actor.unwrap_or(SqlValue::Null);
+    conn.create_scalar_function(
+        "spock_actor",
+        0,
+        FunctionFlags::SQLITE_UTF8 | FunctionFlags::SQLITE_DIRECTONLY,
+        move |_| Ok(value.clone()),
+    )
 }
 
 /// Validate every fn's SQL escapes at load (§7.4), after DDL (tables must
@@ -473,6 +500,7 @@ mod tests {
             f,
             &mut conn,
             &serde_json::Map::from_iter([("body".to_string(), "hi".into())]),
+            None,
         )
         .expect("insert with omitted defaults");
         // a v7 uuid from the engine's own mint, not a hand-rolled v4
@@ -486,7 +514,7 @@ mod tests {
 
         // and the builtins are directly callable from a body
         let f = contract.fn_def("stamp").expect("declared");
-        let now = crate::func::call(&contract, f, &mut conn, &serde_json::Map::new())
+        let now = crate::func::call(&contract, f, &mut conn, &serde_json::Map::new(), None)
             .expect("spock_now() resolves in an escape body");
         time::OffsetDateTime::parse(now.as_str().unwrap(), &Rfc3339).expect("rfc 3339");
     }
@@ -645,6 +673,7 @@ mod tests {
             f,
             &mut conn,
             &serde_json::Map::from_iter([("username".to_string(), "maya".into())]),
+            None,
         )
         .expect_err("NULL under a required field is a contract break");
         assert_eq!(err.code, "internal");

--- a/crates/spock-runtime/src/engine.rs
+++ b/crates/spock-runtime/src/engine.rs
@@ -202,8 +202,10 @@ fn validate_fns(contract: &Contract, conn: &Connection) -> Result<(), EngineErro
             // unknown fails loudly.
             match first_keyword(sql) {
                 Some(kw)
-                    if ["SELECT", "INSERT", "UPDATE", "DELETE", "REPLACE", "WITH", "VALUES"]
-                        .contains(&kw.to_ascii_uppercase().as_str()) => {}
+                    if [
+                        "SELECT", "INSERT", "UPDATE", "DELETE", "REPLACE", "WITH", "VALUES",
+                    ]
+                    .contains(&kw.to_ascii_uppercase().as_str()) => {}
                 Some(kw) => {
                     return Err(at(format!(
                         "`{kw}` is not a fn statement (a body reads and writes rows: \
@@ -237,7 +239,7 @@ fn validate_fns(contract: &Contract, conn: &Connection) -> Result<(), EngineErro
             for i in 1..=stmt.parameter_count() {
                 let Some(name) = stmt.parameter_name(i) else {
                     return Err(at(
-                        "positional parameters are not allowed; use `:param`".into(),
+                        "positional parameters are not allowed; use `:param`".into()
                     ));
                 };
                 let Some(bare) = name.strip_prefix(':') else {
@@ -399,13 +401,12 @@ fn seed(contract: &Contract, conn: &mut Connection) -> Result<(), EngineError> {
 
         // seed runs before any actor exists (anonymous); a `= me` column
         // must be named explicitly in the row (checker E022, RFD 0014 §14.4).
-        let stored = insert_row(contract, table, conn, &body, None).map_err(|source| {
-            EngineError::Seed {
+        let stored =
+            insert_row(contract, table, conn, &body, None).map_err(|source| EngineError::Seed {
                 index,
                 table: table.name.clone(),
                 source: Box::new(source),
-            }
-        })?;
+            })?;
 
         if let Some(binding) = &row.binding {
             if let Some(key_field) = table.key.first() {
@@ -543,11 +544,9 @@ mod tests {
         let table = contract.table("comment").expect("declared");
 
         let parent_id: String = conn
-            .query_row(
-                "SELECT id FROM comment WHERE body = 'parent'",
-                [],
-                |row| row.get(0),
-            )
+            .query_row("SELECT id FROM comment WHERE body = 'parent'", [], |row| {
+                row.get(0)
+            })
             .unwrap();
         crate::write::delete_row(
             &contract,
@@ -574,48 +573,60 @@ mod tests {
         assert!(open_err("fn f() -> user { unchecked sql(\"SELEC *\") }")
             .contains("not a fn statement"));
         // a real syntax error surfaces SQLite's own message
-        assert!(open_err("fn f() -> user { unchecked sql(\"SELECT FROM WHERE\") }")
-            .contains("does not compile"));
-        // unknown column resolves at prepare
-        assert!(open_err("fn f() -> user { unchecked sql(\"SELECT * FROM user WHERE ghost = 1\") }")
-            .contains("does not compile"));
-        // exactly one statement per escape
         assert!(
-            open_err("fn f() -> user { unchecked sql(\"SELECT * FROM user; SELECT * FROM user\") }")
-                .contains("exactly one SQL statement")
+            open_err("fn f() -> user { unchecked sql(\"SELECT FROM WHERE\") }")
+                .contains("does not compile")
         );
+        // unknown column resolves at prepare
+        assert!(open_err(
+            "fn f() -> user { unchecked sql(\"SELECT * FROM user WHERE ghost = 1\") }"
+        )
+        .contains("does not compile"));
+        // exactly one statement per escape
+        assert!(open_err(
+            "fn f() -> user { unchecked sql(\"SELECT * FROM user; SELECT * FROM user\") }"
+        )
+        .contains("exactly one SQL statement"));
         // empty and comment-only bodies
         assert!(open_err("fn f() -> user { unchecked sql(\"\") }").contains("no SQL statement"));
-        assert!(open_err("fn f() -> user { unchecked sql(\"-- nothing\") }").contains("no SQL statement"));
+        assert!(open_err("fn f() -> user { unchecked sql(\"-- nothing\") }")
+            .contains("no SQL statement"));
         // placeholder spellings: bare `?` is nameless (→ positional error);
         // `?1` and `@a` carry their spelling as the name (→ :param error)
         assert!(
             open_err("fn f(a: int) -> user { unchecked sql(\"SELECT * FROM user LIMIT ?\") }")
                 .contains("positional")
         );
-        assert!(
-            open_err("fn f(a: int) -> user { unchecked sql(\"SELECT * FROM user LIMIT ?1\") }")
-                .contains(":param")
-        );
-        assert!(open_err("fn f(a: int) -> user { unchecked sql(\"SELECT * FROM user LIMIT @a\") }")
-            .contains(":param"));
+        assert!(open_err(
+            "fn f(a: int) -> user { unchecked sql(\"SELECT * FROM user LIMIT ?1\") }"
+        )
+        .contains(":param"));
+        assert!(open_err(
+            "fn f(a: int) -> user { unchecked sql(\"SELECT * FROM user LIMIT @a\") }"
+        )
+        .contains(":param"));
         // both directions of the placeholder check
+        assert!(open_err(
+            "fn f() -> user { unchecked sql(\"SELECT * FROM user WHERE id = :ghost\") }"
+        )
+        .contains("not a parameter"));
         assert!(
-            open_err("fn f() -> user { unchecked sql(\"SELECT * FROM user WHERE id = :ghost\") }")
-                .contains("not a parameter")
+            open_err("fn f(a: int) -> user { unchecked sql(\"SELECT * FROM user\") }")
+                .contains("never used")
         );
-        assert!(open_err("fn f(a: int) -> user { unchecked sql(\"SELECT * FROM user\") }")
-            .contains("never used"));
         // a scalar return is exactly one column, any name
         assert!(open_err("fn f() -> int { unchecked sql(\"SELECT 1, 2\") }")
             .contains("exactly one column"));
         open_ok("fn f() -> int { unchecked sql(\"SELECT count(*) FROM user\") }");
         // column set-equality, duplicates, and DML-without-RETURNING
-        assert!(open_err("fn f() -> user { unchecked sql(\"SELECT id FROM user\") }").contains("do not match"));
         assert!(
-            open_err("fn f() -> user { unchecked sql(\"SELECT id AS username, username FROM user\") }")
-                .contains("duplicate column")
+            open_err("fn f() -> user { unchecked sql(\"SELECT id FROM user\") }")
+                .contains("do not match")
         );
+        assert!(open_err(
+            "fn f() -> user { unchecked sql(\"SELECT id AS username, username FROM user\") }"
+        )
+        .contains("duplicate column"));
         assert!(open_err(
             "mut fn f(username: text) -> user { unchecked sql(\"UPDATE user SET username = :username\") }"
         )

--- a/crates/spock-runtime/src/func.rs
+++ b/crates/spock-runtime/src/func.rs
@@ -54,6 +54,7 @@ pub fn call(
     f: &FnDef,
     conn: &mut Connection,
     args: &Map<String, Json>,
+    actor: Option<SqlValue>,
 ) -> Result<Json, ApiError> {
     // unknown arguments are rejected; missing required ones refuse early
     for name in args.keys() {
@@ -76,6 +77,15 @@ pub fn call(
             }
         };
         binds.push((format!(":{}", p.name), value));
+    }
+
+    // re-bind `spock_actor()` to this request's actor before the tx opens
+    // (RFD 0014 §4.3). Only when an anchor exists — otherwise the builtin
+    // is unregistered and no validated body references it (E-ACT03). The
+    // single serialized connection makes the per-call re-bind race-free.
+    if contract.anchor().is_some() {
+        crate::engine::register_actor(conn, actor)
+            .map_err(|e| ApiError::internal(format!("sqlite: {e}")))?;
     }
 
     // one transaction spans the whole body: IMMEDIATE for `mut` fns (the
@@ -345,6 +355,88 @@ seed {
             .iter()
             .map(|(k, v)| (k.to_string(), v.clone()))
             .collect()
+    }
+
+    /// Test shim (shadows `super::call`): these fixtures declare no anchor,
+    /// so every call runs anonymous — the actor is always `None`. Actor-aware
+    /// behavior is covered by the runtime's dedicated actor tests.
+    fn call(
+        contract: &Contract,
+        f: &FnDef,
+        conn: &mut Connection,
+        args: &Map<String, Json>,
+    ) -> Result<Json, ApiError> {
+        super::call(contract, f, conn, args, None)
+    }
+
+    #[test]
+    fn spock_actor_reads_the_request_actor() {
+        // a natural (text) anchor key lets the test control the actor value
+        let contract = spock_lang::compile(
+            "auth table account { key handle: text }\n\
+             fn whoami() -> text? { unchecked sql(\"SELECT spock_actor()\") }\n\
+             seed { account { handle: \"maya\" } }",
+        )
+        .expect("compiles");
+        let mut conn = engine::open(&contract, None).expect("loads");
+        let f = contract.fn_def("whoami").unwrap();
+        // anonymous (no actor) → NULL
+        assert!(super::call(&contract, f, &mut conn, &Map::new(), None)
+            .unwrap()
+            .is_null());
+        // impersonated → the actor's key, verbatim
+        let maya = super::call(
+            &contract,
+            f,
+            &mut conn,
+            &Map::new(),
+            Some(SqlValue::Text("maya".into())),
+        )
+        .unwrap();
+        assert_eq!(maya, "maya");
+    }
+
+    #[test]
+    fn spock_actor_stamps_a_written_column() {
+        let contract = spock_lang::compile(
+            "auth table account { key handle: text }\n\
+             table note { key id: uuid = auto\n owner: account\n body: text }\n\
+             mut fn add_note(body: text) -> note {\n\
+               unchecked sql(\"INSERT INTO note (owner, body) VALUES (spock_actor(), :body) RETURNING *\")\n\
+             }\n\
+             seed { account { handle: \"maya\" } }",
+        )
+        .expect("compiles");
+        let mut conn = engine::open(&contract, None).expect("loads");
+        let f = contract.fn_def("add_note").unwrap();
+        let note = super::call(
+            &contract,
+            f,
+            &mut conn,
+            &args(&[("body", "hi".into())]),
+            Some(SqlValue::Text("maya".into())),
+        )
+        .unwrap();
+        // the actor was stamped into the stored `owner` column, unforgeable
+        assert_eq!(note["owner"], "maya");
+        assert_eq!(note["body"], "hi");
+    }
+
+    #[test]
+    fn spock_actor_without_an_anchor_fails_at_load() {
+        // E-ACT03: with no `auth table`, spock_actor() is never registered, so
+        // a body that calls it fails to prepare at load — identity needs a
+        // consumer, enforced mechanically.
+        let contract = spock_lang::compile(
+            "table t { key id: uuid = auto }\n\
+             fn whoami() -> uuid? { unchecked sql(\"SELECT spock_actor()\") }",
+        )
+        .expect("compiles");
+        let err = engine::open(&contract, None).expect_err("no anchor → spock_actor unresolved");
+        assert!(
+            format!("{err}").contains("spock_actor"),
+            "expected a 'no such function: spock_actor' load error, got: {err}"
+        );
     }
 
     fn user_id(contract: &Contract, conn: &mut Connection, username: &str) -> String {

--- a/crates/spock-runtime/src/func.rs
+++ b/crates/spock-runtime/src/func.rs
@@ -423,6 +423,34 @@ seed {
     }
 
     #[test]
+    fn me_default_stamps_and_routes_anonymous() {
+        let contract = spock_lang::compile(
+            "auth table account { key handle: text }\n\
+             table note { key id: uuid = auto\n owner: account = me\n body: text }\n\
+             seed { account { handle: \"maya\" } }",
+        )
+        .expect("compiles");
+        let mut conn = engine::open(&contract, None).expect("loads");
+        let note = contract.table("note").unwrap();
+        let body = args(&[("body", "hi".into())]);
+        // impersonated → owner stamped from the actor, never from the body
+        let row = crate::write::insert_row(
+            &contract,
+            note,
+            &mut conn,
+            &body,
+            Some(SqlValue::Text("maya".into())),
+        )
+        .unwrap();
+        assert_eq!(row["owner"], "maya");
+        assert_eq!(row["body"], "hi");
+        // anonymous → the derived `required` error (422), NOT a raw NOT NULL
+        // 500 the floor's map_conflict_error can't translate (§14.4)
+        let err = crate::write::insert_row(&contract, note, &mut conn, &body, None).unwrap_err();
+        assert_eq!(err.code, "note_owner_required");
+    }
+
+    #[test]
     fn spock_actor_without_an_anchor_fails_at_load() {
         // E-ACT03: with no `auth table`, spock_actor() is never registered, so
         // a body that calls it fails to prepare at load — identity needs a

--- a/crates/spock-runtime/src/func.rs
+++ b/crates/spock-runtime/src/func.rs
@@ -143,9 +143,7 @@ pub fn call(
                             .iter()
                             .find(|(n, _, _)| *n == col.as_str())
                             .map(|(_, ty, optional)| (contract.value_type(ty), *optional))
-                            .ok_or_else(|| {
-                                ApiError::internal("contract drift: unvalidated column")
-                            })
+                            .ok_or_else(|| ApiError::internal("contract drift: unvalidated column"))
                     })
                     .collect::<Result<_, _>>()?
             }
@@ -478,9 +476,21 @@ seed {
         let (contract, mut conn) = setup();
         // maybe: hit and null miss
         let f = contract.fn_def("find_user").unwrap();
-        let row = call(&contract, f, &mut conn, &args(&[("username", "maya".into())])).unwrap();
+        let row = call(
+            &contract,
+            f,
+            &mut conn,
+            &args(&[("username", "maya".into())]),
+        )
+        .unwrap();
         assert_eq!(row["bio"], "photographer");
-        let miss = call(&contract, f, &mut conn, &args(&[("username", "ghost".into())])).unwrap();
+        let miss = call(
+            &contract,
+            f,
+            &mut conn,
+            &args(&[("username", "ghost".into())]),
+        )
+        .unwrap();
         assert!(miss.is_null());
         // many
         let f = contract.fn_def("all_users").unwrap();
@@ -489,7 +499,13 @@ seed {
         // record return: an aggregate as a shape
         let maya = user_id(&contract, &mut conn, "maya");
         let f = contract.fn_def("user_stats").unwrap();
-        let stats = call(&contract, f, &mut conn, &args(&[("user", maya.clone().into())])).unwrap();
+        let stats = call(
+            &contract,
+            f,
+            &mut conn,
+            &args(&[("user", maya.clone().into())]),
+        )
+        .unwrap();
         assert_eq!(stats["posts"], 1);
         // float param binds Real; the result maps back as a JSON number
         let f = contract.fn_def("double").unwrap();
@@ -509,11 +525,29 @@ seed {
         // -> text?: a value... (bio is a nullable column: a stored NULL and
         // a missing row both surface as null)
         let f = contract.fn_def("bio_of").unwrap();
-        let hit = call(&contract, f, &mut conn, &args(&[("username", "maya".into())])).unwrap();
+        let hit = call(
+            &contract,
+            f,
+            &mut conn,
+            &args(&[("username", "maya".into())]),
+        )
+        .unwrap();
         assert_eq!(hit, "photographer");
-        let none = call(&contract, f, &mut conn, &args(&[("username", "luis".into())])).unwrap();
+        let none = call(
+            &contract,
+            f,
+            &mut conn,
+            &args(&[("username", "luis".into())]),
+        )
+        .unwrap();
         assert!(none.is_null());
-        let miss = call(&contract, f, &mut conn, &args(&[("username", "ghost".into())])).unwrap();
+        let miss = call(
+            &contract,
+            f,
+            &mut conn,
+            &args(&[("username", "ghost".into())]),
+        )
+        .unwrap();
         assert!(miss.is_null());
         // -> [text]: bare values in order
         let f = contract.fn_def("usernames").unwrap();
@@ -608,14 +642,23 @@ seed {
             &contract,
             f,
             &mut conn,
-            &args(&[("author", maya.clone().into()), ("caption", "second".into())]),
+            &args(&[
+                ("author", maya.clone().into()),
+                ("caption", "second".into()),
+            ]),
         )
         .unwrap();
         assert_eq!(n, 2); // the seed post + this one
-        // one transaction: a violated `-> t` arity rolls EVERY statement
-        // back, including earlier effects
+                          // one transaction: a violated `-> t` arity rolls EVERY statement
+                          // back, including earlier effects
         let f = contract.fn_def("insert_then_miss").unwrap();
-        let err = call(&contract, f, &mut conn, &args(&[("author", maya.clone().into())])).unwrap_err();
+        let err = call(
+            &contract,
+            f,
+            &mut conn,
+            &args(&[("author", maya.clone().into())]),
+        )
+        .unwrap_err();
         assert_eq!(err.code, "not_found");
         let f = contract.fn_def("post_and_count").unwrap();
         let n = call(
@@ -635,9 +678,24 @@ seed {
         // a read fn refuses too — SELECT + spock_refuse stays readonly,
         // proven by the engine accepting checked_bio at open()
         let f = contract.fn_def("checked_bio").unwrap();
-        let err = call(&contract, f, &mut conn, &args(&[("username", "luis".into())])).unwrap_err();
-        assert_eq!((err.code.as_str(), err.kind, err.status), ("bio_missing", "refused", 409));
-        let hit = call(&contract, f, &mut conn, &args(&[("username", "maya".into())])).unwrap();
+        let err = call(
+            &contract,
+            f,
+            &mut conn,
+            &args(&[("username", "luis".into())]),
+        )
+        .unwrap_err();
+        assert_eq!(
+            (err.code.as_str(), err.kind, err.status),
+            ("bio_missing", "refused", 409)
+        );
+        let hit = call(
+            &contract,
+            f,
+            &mut conn,
+            &args(&[("username", "maya".into())]),
+        )
+        .unwrap();
         assert_eq!(hit, "photographer");
         // a minted refusal fires with its own name — no more collapsed
         // not_found lies (v0-FEEDBACK G2)
@@ -655,23 +713,44 @@ seed {
             &contract,
             f,
             &mut conn,
-            &args(&[("user", maya.clone().into()), ("username", "maya_ok".into())]),
+            &args(&[
+                ("user", maya.clone().into()),
+                ("username", "maya_ok".into()),
+            ]),
         )
         .unwrap();
         assert_eq!(row["username"], "maya_ok");
         // an unminted raise is the body breaking its signature
         let f = contract.fn_def("rogue").unwrap();
-        let err = call(&contract, f, &mut conn, &args(&[("author", maya.clone().into())])).unwrap_err();
+        let err = call(
+            &contract,
+            f,
+            &mut conn,
+            &args(&[("author", maya.clone().into())]),
+        )
+        .unwrap_err();
         assert_eq!(err.code, "internal");
         assert!(err.message.contains("never_declared"), "{}", err.message);
         // a derived code cannot be raised — evidence is not borrowable
         let f = contract.fn_def("counterfeit").unwrap();
-        let err = call(&contract, f, &mut conn, &args(&[("author", maya.clone().into())])).unwrap_err();
+        let err = call(
+            &contract,
+            f,
+            &mut conn,
+            &args(&[("author", maya.clone().into())]),
+        )
+        .unwrap_err();
         assert_eq!(err.code, "internal");
         assert!(err.message.contains("own mechanism"), "{}", err.message);
         // a refusal rolls back everything before it — one transaction
         let f = contract.fn_def("post_then_refuse").unwrap();
-        let err = call(&contract, f, &mut conn, &args(&[("author", maya.clone().into())])).unwrap_err();
+        let err = call(
+            &contract,
+            f,
+            &mut conn,
+            &args(&[("author", maya.clone().into())]),
+        )
+        .unwrap_err();
         assert_eq!(err.code, "always_no");
         let f = contract.fn_def("post_and_count").unwrap();
         let n = call(

--- a/crates/spock-runtime/src/graphql.rs
+++ b/crates/spock-runtime/src/graphql.rs
@@ -153,11 +153,26 @@ pub fn schema(app: Arc<App>) -> Result<Schema, SchemaBuildError> {
     let dup_query: Collide = |a, b, name| SchemaBuildError::DuplicateQueryField { a, b, name };
     for table in &contract.tables {
         let owner = format!("table `{}`", table.name);
-        claim(&mut claimed_roots, table.name.clone(), owner.clone(), dup_query)?;
-        claim(&mut claimed_roots, format!("{}_by_pk", table.name), owner, dup_query)?;
+        claim(
+            &mut claimed_roots,
+            table.name.clone(),
+            owner.clone(),
+            dup_query,
+        )?;
+        claim(
+            &mut claimed_roots,
+            format!("{}_by_pk", table.name),
+            owner,
+            dup_query,
+        )?;
     }
     for f in contract.fns.iter().filter(|f| f.readonly) {
-        claim(&mut claimed_roots, f.name.clone(), format!("fn `{}`", f.name), dup_query)?;
+        claim(
+            &mut claimed_roots,
+            f.name.clone(),
+            format!("fn `{}`", f.name),
+            dup_query,
+        )?;
     }
 
     // Pass 1c — mutation-root field names. Derived CRUD names could once
@@ -165,17 +180,38 @@ pub fn schema(app: Arc<App>) -> Result<Schema, SchemaBuildError> {
     // everything registered on the root is claimed — exactly what is
     // registered (a pure-key table claims no update).
     let mut claimed_mutations: HashMap<String, String> = HashMap::new(); // field -> owner
-    let dup_mutation: Collide = |a, b, name| SchemaBuildError::DuplicateMutationField { a, b, name };
+    let dup_mutation: Collide =
+        |a, b, name| SchemaBuildError::DuplicateMutationField { a, b, name };
     for table in &contract.tables {
         let owner = format!("table `{}`", table.name);
-        claim(&mut claimed_mutations, format!("insert_{}_one", table.name), owner.clone(), dup_mutation)?;
+        claim(
+            &mut claimed_mutations,
+            format!("insert_{}_one", table.name),
+            owner.clone(),
+            dup_mutation,
+        )?;
         if has_settable_fields(table) {
-            claim(&mut claimed_mutations, format!("update_{}_by_pk", table.name), owner.clone(), dup_mutation)?;
+            claim(
+                &mut claimed_mutations,
+                format!("update_{}_by_pk", table.name),
+                owner.clone(),
+                dup_mutation,
+            )?;
         }
-        claim(&mut claimed_mutations, format!("delete_{}_by_pk", table.name), owner, dup_mutation)?;
+        claim(
+            &mut claimed_mutations,
+            format!("delete_{}_by_pk", table.name),
+            owner,
+            dup_mutation,
+        )?;
     }
     for f in contract.fns.iter().filter(|f| !f.readonly) {
-        claim(&mut claimed_mutations, f.name.clone(), format!("fn `{}`", f.name), dup_mutation)?;
+        claim(
+            &mut claimed_mutations,
+            f.name.clone(),
+            format!("fn `{}`", f.name),
+            dup_mutation,
+        )?;
     }
 
     // Pass 2 — object types (declared fields, forward refs, reverse
@@ -1041,7 +1077,11 @@ fn fn_field(contract: &Contract, f: &FnDef) -> Field {
             };
             let scalar = f.returns.scalar;
             let wrap = |v: Json| -> async_graphql::Result<FieldValue<'static>> {
-                if scalar { leaf(v) } else { Ok(FieldValue::owned_any(v)) }
+                if scalar {
+                    leaf(v)
+                } else {
+                    Ok(FieldValue::owned_any(v))
+                }
             };
             Ok(match f.returns.arity {
                 FnArity::One => Some(wrap(result)?),
@@ -1149,13 +1189,24 @@ mod tests {
         // insert_input: every field, all nullable — required-ness is the
         // runtime's (the derived error stays un-shadowed)
         let insert_input = sdl_block(&sdl, "input user_insert_input");
-        for field in ["id: uuid", "username: String", "bio: String", "joined_at: timestamp"] {
-            assert!(insert_input.contains(&field.to_string()), "{insert_input:?}");
+        for field in [
+            "id: uuid",
+            "username: String",
+            "bio: String",
+            "joined_at: timestamp",
+        ] {
+            assert!(
+                insert_input.contains(&field.to_string()),
+                "{insert_input:?}"
+            );
         }
 
         // set_input: non-key fields only, all nullable
         let set_input = sdl_block(&sdl, "input user_set_input");
-        assert!(!set_input.iter().any(|l| l.starts_with("id:")), "{set_input:?}");
+        assert!(
+            !set_input.iter().any(|l| l.starts_with("id:")),
+            "{set_input:?}"
+        );
         for field in ["username: String", "bio: String", "joined_at: timestamp"] {
             assert!(set_input.contains(&field.to_string()), "{set_input:?}");
         }
@@ -1166,7 +1217,10 @@ mod tests {
 
         // mutation shapes (graphql.md §5)
         let insert = sdl_line(&sdl, "insert_user_one(");
-        assert!(insert.contains("(object: user_insert_input!): user!"), "{insert}");
+        assert!(
+            insert.contains("(object: user_insert_input!): user!"),
+            "{insert}"
+        );
         let update = sdl_line(&sdl, "update_user_by_pk(");
         assert!(
             update.contains("(pk_columns: user_pk_columns_input!, _set: user_set_input!): user!"),
@@ -1175,7 +1229,10 @@ mod tests {
 
         // composite keys: full key args on delete and on the by-pk query
         let delete = sdl_line(&sdl, "delete_follow_by_pk(");
-        assert!(delete.contains("follower: uuid!, target: uuid!"), "{delete}");
+        assert!(
+            delete.contains("follower: uuid!, target: uuid!"),
+            "{delete}"
+        );
         let by_pk = sdl_line(&sdl, "follow_by_pk(");
         assert!(
             by_pk.contains("follower: uuid!, target: uuid!): follow"),
@@ -1219,8 +1276,8 @@ mod tests {
         // `uuid`/`timestamp` never get this far — they are type keywords
         // the parser already rejects as table names (L010)
         for table in ["query", "mutation", "subscription"] {
-            let err = build(&format!("table {table} {{ key id: uuid = auto\n a: int }}"))
-                .unwrap_err();
+            let err =
+                build(&format!("table {table} {{ key id: uuid = auto\n a: int }}")).unwrap_err();
             assert!(
                 matches!(err, SchemaBuildError::ReservedTableName { .. }),
                 "{table}: {err}"

--- a/crates/spock-runtime/src/graphql.rs
+++ b/crates/spock-runtime/src/graphql.rs
@@ -394,6 +394,19 @@ fn gql<E: std::fmt::Display>(e: E) -> async_graphql::Error {
     async_graphql::Error::new(e.to_string())
 }
 
+/// The per-request actor (RFD 0014), injected into each GraphQL request via
+/// `Request::data` by the HTTP layer (never the schema-global `.data`, which
+/// would bleed across requests — §14.3). Resolvers read it with
+/// `ctx.data_opt::<CurrentActor>()`.
+#[derive(Clone, Default)]
+pub struct CurrentActor(pub Option<SqlValue>);
+
+/// The current actor from the resolver context, or `None` when anonymous /
+/// unset. Cloned because `SqlValue` is not `Copy`.
+fn actor_of(ctx: &ResolverContext<'_>) -> Option<SqlValue> {
+    ctx.data_opt::<CurrentActor>().and_then(|a| a.0.clone())
+}
+
 fn app_of<'a>(ctx: &ResolverContext<'a>) -> Result<&'a Arc<App>, async_graphql::Error> {
     ctx.data::<Arc<App>>()
 }
@@ -1004,9 +1017,10 @@ fn fn_field(contract: &Contract, f: &FnDef) -> Field {
                 }
                 args.insert(p.name.clone(), v.deserialize::<Json>()?);
             }
+            let actor = actor_of(&ctx);
             let result = {
                 let mut db = app.db.lock().map_err(|_| gql("db lock poisoned"))?;
-                func::call(contract, f, &mut db, &args).map_err(api_error_to_gql)?
+                func::call(contract, f, &mut db, &args, actor).map_err(api_error_to_gql)?
             };
             let scalar = f.returns.scalar;
             let wrap = |v: Json| -> async_graphql::Result<FieldValue<'static>> {

--- a/crates/spock-runtime/src/graphql.rs
+++ b/crates/spock-runtime/src/graphql.rs
@@ -37,7 +37,7 @@ use async_graphql_value::Value as AstValue;
 use rusqlite::types::Value as SqlValue;
 use serde_json::{Map, Value as Json};
 use spock_lang::ir::{
-    Contract, DefaultValue, DerivedError, ErrorKind, Field as IrField, FnArity, FnDef, Table, Type,
+    Contract, DerivedError, ErrorKind, Field as IrField, FnArity, FnDef, Table, Type,
 };
 use time::format_description::well_known::Rfc3339;
 
@@ -305,13 +305,7 @@ fn has_settable_fields(table: &Table) -> bool {
     table
         .fields
         .iter()
-        .any(|f| !table.key.contains(&f.name) && !is_actor_default(f))
-}
-
-/// A `= me` field (RFD 0014): stamped by the runtime, removed from the
-/// client insert/update surface.
-fn is_actor_default(field: &IrField) -> bool {
-    matches!(field.default, Some(DefaultValue::Actor))
+        .any(|f| !table.key.contains(&f.name) && !f.is_actor_default())
 }
 
 /// A root's collision error, built from (prior owner, new owner, field).
@@ -366,7 +360,7 @@ fn insert_input_type(contract: &Contract, table: &Table) -> InputObject {
     for f in &table.fields {
         // `= me` fields (RFD 0014) leave the client insert surface: the
         // runtime stamps the actor, so a client cannot forge them.
-        if is_actor_default(f) {
+        if f.is_actor_default() {
             continue;
         }
         input = input.field(InputValue::new(
@@ -385,7 +379,7 @@ fn set_input_type(contract: &Contract, table: &Table) -> InputObject {
     for f in &table.fields {
         // keys are immutable; `= me` fields are stamped once and never
         // reassigned by a client (RFD 0014) — both leave the update surface.
-        if table.key.contains(&f.name) || is_actor_default(f) {
+        if table.key.contains(&f.name) || f.is_actor_default() {
             continue;
         }
         input = input.field(InputValue::new(
@@ -417,7 +411,6 @@ fn gql<E: std::fmt::Display>(e: E) -> async_graphql::Error {
 /// `Request::data` by the HTTP layer (never the schema-global `.data`, which
 /// would bleed across requests — §14.3). Resolvers read it with
 /// `ctx.data_opt::<CurrentActor>()`.
-#[derive(Clone, Default)]
 pub struct CurrentActor(pub Option<SqlValue>);
 
 /// The current actor from the resolver context, or `None` when anonymous /

--- a/crates/spock-runtime/src/graphql.rs
+++ b/crates/spock-runtime/src/graphql.rs
@@ -37,7 +37,7 @@ use async_graphql_value::Value as AstValue;
 use rusqlite::types::Value as SqlValue;
 use serde_json::{Map, Value as Json};
 use spock_lang::ir::{
-    Contract, DerivedError, ErrorKind, Field as IrField, FnArity, FnDef, Table, Type,
+    Contract, DefaultValue, DerivedError, ErrorKind, Field as IrField, FnArity, FnDef, Table, Type,
 };
 use time::format_description::well_known::Rfc3339;
 
@@ -296,10 +296,22 @@ pub fn schema(app: Arc<App>) -> Result<Schema, SchemaBuildError> {
     Ok(builder.finish()?)
 }
 
-/// Whether the table has any non-key field — the precondition for deriving
-/// `update_<t>_by_pk` and its input types.
+/// Whether the table has any client-settable field — the precondition for
+/// deriving `update_<t>_by_pk` and its input types. Excludes keys (immutable)
+/// and `= me` fields (RFD 0014: server-stamped, off the client surface). If
+/// none remain, no `_set` input is emitted — an empty GraphQL input object is
+/// invalid and would fail schema build (§14.4).
 fn has_settable_fields(table: &Table) -> bool {
-    table.fields.iter().any(|f| !table.key.contains(&f.name))
+    table
+        .fields
+        .iter()
+        .any(|f| !table.key.contains(&f.name) && !is_actor_default(f))
+}
+
+/// A `= me` field (RFD 0014): stamped by the runtime, removed from the
+/// client insert/update surface.
+fn is_actor_default(field: &IrField) -> bool {
+    matches!(field.default, Some(DefaultValue::Actor))
 }
 
 /// A root's collision error, built from (prior owner, new owner, field).
@@ -352,6 +364,11 @@ fn scalar_name(contract: &Contract, ty: &Type) -> &'static str {
 fn insert_input_type(contract: &Contract, table: &Table) -> InputObject {
     let mut input = InputObject::new(insert_input_name(&table.name));
     for f in &table.fields {
+        // `= me` fields (RFD 0014) leave the client insert surface: the
+        // runtime stamps the actor, so a client cannot forge them.
+        if is_actor_default(f) {
+            continue;
+        }
         input = input.field(InputValue::new(
             f.name.clone(),
             TypeRef::named(scalar_name(contract, &f.ty)),
@@ -366,7 +383,9 @@ fn insert_input_type(contract: &Contract, table: &Table) -> InputObject {
 fn set_input_type(contract: &Contract, table: &Table) -> InputObject {
     let mut input = InputObject::new(set_input_name(&table.name));
     for f in &table.fields {
-        if table.key.contains(&f.name) {
+        // keys are immutable; `= me` fields are stamped once and never
+        // reassigned by a client (RFD 0014) — both leave the update surface.
+        if table.key.contains(&f.name) || is_actor_default(f) {
             continue;
         }
         input = input.field(InputValue::new(
@@ -860,9 +879,14 @@ fn insert_one_field(table: &Table) -> Field {
                         body.insert(f.name.clone(), v.deserialize::<Json>()?);
                     }
                 }
+                // `= me` fields are absent from the input by construction
+                // (removed from insert_input_type); the runtime stamps the
+                // request actor for them (RFD 0014 §14.3).
+                let actor = actor_of(&ctx);
                 let row = {
                     let mut db = app.db.lock().map_err(|_| gql("db lock poisoned"))?;
-                    write::insert_row(contract, table, &mut db, &body).map_err(api_error_to_gql)?
+                    write::insert_row(contract, table, &mut db, &body, actor)
+                        .map_err(api_error_to_gql)?
                 };
                 Ok(Some(FieldValue::owned_any(row)))
             })

--- a/crates/spock-runtime/src/http.rs
+++ b/crates/spock-runtime/src/http.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use async_graphql::dynamic::Schema;
 use async_graphql::http::GraphiQLSource;
 use axum::extract::{Path, Query, State};
+use axum::http::HeaderMap;
 use axum::response::Html;
 use axum::routing::{get, post};
 use axum::{Json, Router};
@@ -47,7 +48,10 @@ pub fn router(app: Arc<App>) -> Result<Router, StartupError> {
     let schema = graphql::schema(app.clone())?;
     let gql = Router::new()
         .route("/graphql/v1", get(graphiql).post(graphql_post))
-        .with_state(schema);
+        .with_state(GqlState {
+            schema,
+            app: app.clone(),
+        });
     Ok(Router::new()
         .route("/~contract", get(contract))
         .route("/~health", get(health))
@@ -66,13 +70,31 @@ pub async fn serve(app: Arc<App>, listener: tokio::net::TcpListener) -> std::io:
     axum::serve(listener, router).await
 }
 
+/// The GraphQL route's state: the derived schema plus the app, so
+/// `graphql_post` can resolve the per-request actor from the header before
+/// executing (RFD 0014 §4.3). The schema carries the app in its own global
+/// data for resolvers; the *actor* rides `Request::data` per request, never
+/// the schema-global channel (§14.3 — that would bleed across requests).
+#[derive(Clone)]
+struct GqlState {
+    schema: Schema,
+    app: Arc<App>,
+}
+
 // POST /graphql/v1 — execute a query (§8.2); errors render as GraphQL's own
 // `errors[]`, not the §8.1 envelope
 async fn graphql_post(
-    State(schema): State<Schema>,
+    State(state): State<GqlState>,
+    headers: HeaderMap,
     Json(request): Json<async_graphql::Request>,
 ) -> Json<async_graphql::Response> {
-    Json(schema.execute(request).await)
+    let actor = resolve_actor(&state.app, &headers);
+    Json(
+        state
+            .schema
+            .execute(request.data(graphql::CurrentActor(actor)))
+            .await,
+    )
 }
 
 // GET /graphql/v1 — GraphiQL. Its JS/CSS load from a CDN: blank offline,
@@ -105,9 +127,11 @@ async fn not_found() -> ApiError {
 async fn rpc_call(
     State(app): State<Arc<App>>,
     Path(name): Path<String>,
+    headers: HeaderMap,
     body: String,
 ) -> Result<Json<JsonValue>, ApiError> {
     let f = resolve_fn(&app, &name)?;
+    let actor = resolve_actor(&app, &headers);
     let args: Map<String, JsonValue> = if body.trim().is_empty() {
         Map::new()
     } else {
@@ -120,7 +144,7 @@ async fn rpc_call(
             Err(e) => return Err(ApiError::bad_request(format!("malformed JSON body: {e}"))),
         }
     };
-    run_rpc(&app, f, &args)
+    run_rpc(&app, f, &args, actor)
 }
 
 // GET /rest/v1/rpc/{fn} — call a *read* fn with query-string arguments
@@ -132,9 +156,11 @@ async fn rpc_call(
 async fn rpc_get(
     State(app): State<Arc<App>>,
     Path(name): Path<String>,
+    headers: HeaderMap,
     Query(params): Query<HashMap<String, String>>,
 ) -> Result<Json<JsonValue>, ApiError> {
     let f = resolve_fn(&app, &name)?;
+    let actor = resolve_actor(&app, &headers);
     if !f.readonly {
         return Err(ApiError::method_not_allowed(format!(
             "fn `{name}` is `mut`; call it with POST"
@@ -150,7 +176,7 @@ async fn rpc_get(
         };
         args.insert(key, value);
     }
-    run_rpc(&app, f, &args)
+    run_rpc(&app, f, &args, actor)
 }
 
 fn resolve_fn<'a>(app: &'a App, name: &str) -> Result<&'a spock_lang::ir::FnDef, ApiError> {
@@ -159,18 +185,31 @@ fn resolve_fn<'a>(app: &'a App, name: &str) -> Result<&'a spock_lang::ir::FnDef,
         .ok_or_else(|| ApiError::not_found(format!("no fn `{name}` in this contract")))
 }
 
+/// The current actor from the `X-Spock-Actor` header (RFD 0014 §4.3), the
+/// dev seam a verified JWT later fills. `None` (anonymous) when there is no
+/// anchor, no header, or a value that does not parse as the anchor's key
+/// type — canonicalized exactly like a by-key path segment so an uppercased
+/// or braced uuid still matches the stored lowercase-canonical key. Never a
+/// 404: a malformed header is anonymous, not an error.
+fn resolve_actor(app: &App, headers: &HeaderMap) -> Option<SqlValue> {
+    let anchor = app.contract.anchor()?;
+    let raw = headers.get("x-spock-actor")?.to_str().ok()?;
+    path_key_value(app, anchor, raw).ok()
+}
+
 /// The shared rpc execution tail: one locked call, arity-shaped envelope.
 fn run_rpc(
     app: &App,
     f: &spock_lang::ir::FnDef,
     args: &Map<String, JsonValue>,
+    actor: Option<SqlValue>,
 ) -> Result<Json<JsonValue>, ApiError> {
     let result = {
         let mut db = app
             .db
             .lock()
             .map_err(|_| ApiError::internal("db lock poisoned"))?;
-        func::call(&app.contract, f, &mut db, args)?
+        func::call(&app.contract, f, &mut db, args, actor)?
     };
     Ok(Json(match f.returns.arity {
         // list results share the REST list envelope

--- a/crates/spock-runtime/src/http.rs
+++ b/crates/spock-runtime/src/http.rs
@@ -22,8 +22,8 @@ use spock_lang::ir::{FnArity, Table, Type};
 
 use crate::error::ApiError;
 use crate::graphql::{self, SchemaBuildError};
-use crate::{func, write};
 use crate::App;
+use crate::{func, write};
 
 const DEFAULT_LIMIT: u32 = 50;
 const MAX_LIMIT: u32 = 200;

--- a/crates/spock-runtime/src/write.rs
+++ b/crates/spock-runtime/src/write.rs
@@ -432,8 +432,7 @@ fn map_conflict_error(table: &Table, e: rusqlite::Error) -> ApiError {
 fn check_constraint_code(code: std::os::raw::c_int, msg: &str) -> Option<&str> {
     use rusqlite::ffi;
     if code == ffi::SQLITE_CONSTRAINT_CHECK {
-        msg.strip_prefix("CHECK constraint failed: ")
-            .map(str::trim)
+        msg.strip_prefix("CHECK constraint failed: ").map(str::trim)
     } else {
         None
     }
@@ -446,10 +445,19 @@ fn check_constraint_code(code: std::os::raw::c_int, msg: &str) -> Option<&str> {
 fn invalid_error(table: &Table, derr: &DerivedError) -> ApiError {
     let message = if let [field_name] = derr.fields.as_slice() {
         match table.field(field_name) {
-            Some(Field { ty: Type::Set { values }, .. }) => {
-                format!("`{}.{field_name}` must be one of: {}", table.name, values.join(", "))
+            Some(Field {
+                ty: Type::Set { values },
+                ..
+            }) => {
+                format!(
+                    "`{}.{field_name}` must be one of: {}",
+                    table.name,
+                    values.join(", ")
+                )
             }
-            Some(Field { check: Some(check), .. }) => {
+            Some(Field {
+                check: Some(check), ..
+            }) => {
                 format!("`{}.{field_name}` failed check `{check}`", table.name)
             }
             _ => format!("`{}` value constraint `{}` failed", table.name, derr.code),

--- a/crates/spock-runtime/src/write.rs
+++ b/crates/spock-runtime/src/write.rs
@@ -18,6 +18,7 @@ pub fn insert_row(
     table: &Table,
     conn: &mut Connection,
     body: &Map<String, Json>,
+    actor: Option<SqlValue>,
 ) -> Result<Json, ApiError> {
     // 1. unknown fields are rejected
     for name in body.keys() {
@@ -38,6 +39,24 @@ pub fn insert_row(
                 // spock_now() — one clock, one id format, both paths
                 Some(DefaultValue::Auto) => SqlValue::Text(crate::value::new_uuid()),
                 Some(DefaultValue::Now) => SqlValue::Text(crate::value::now_utc()),
+                // `= me` (RFD 0014): stamp the request actor. A required
+                // column with no actor (anonymous) routes to the derived
+                // `required` error HERE — not a NULL that the floor's
+                // map_conflict_error can't translate (it would 500). §14.4.
+                Some(DefaultValue::Actor) => match &actor {
+                    Some(a) => a.clone(),
+                    None if field.optional => SqlValue::Null,
+                    None => {
+                        let err = table
+                            .error_for(ErrorKind::Required, &[&field.name])
+                            .ok_or_else(|| ApiError::internal("missing derived required error"))?;
+                        return Err(ApiError::derived(
+                            &table.name,
+                            err,
+                            format!("{}.{} is required", table.name, field.name),
+                        ));
+                    }
+                },
                 Some(DefaultValue::Str { value }) => SqlValue::Text(value.clone()),
                 Some(DefaultValue::Int { value }) => SqlValue::Integer(*value),
                 Some(DefaultValue::Float { value }) => SqlValue::Real(*value),

--- a/crates/spock-runtime/src/write.rs
+++ b/crates/spock-runtime/src/write.rs
@@ -39,30 +39,18 @@ pub fn insert_row(
                 // spock_now() — one clock, one id format, both paths
                 Some(DefaultValue::Auto) => SqlValue::Text(crate::value::new_uuid()),
                 Some(DefaultValue::Now) => SqlValue::Text(crate::value::now_utc()),
-                // `= me` (RFD 0014): stamp the request actor. A required
-                // column with no actor (anonymous) routes to the derived
-                // `required` error HERE — not a NULL that the floor's
-                // map_conflict_error can't translate (it would 500). §14.4.
-                Some(DefaultValue::Actor) => match &actor {
-                    Some(a) => a.clone(),
-                    None if field.optional => SqlValue::Null,
-                    None => {
-                        let err = table
-                            .error_for(ErrorKind::Required, &[&field.name])
-                            .ok_or_else(|| ApiError::internal("missing derived required error"))?;
-                        return Err(ApiError::derived(
-                            &table.name,
-                            err,
-                            format!("{}.{} is required", table.name, field.name),
-                        ));
-                    }
-                },
+                // `= me` (RFD 0014): stamp the request actor. When anonymous it
+                // falls through to the no-default arms below — an
+                // unauthenticated `= me` is exactly a missing required field,
+                // routed to the derived `required` error there (not a NULL the
+                // floor's map_conflict_error would 500 on). §14.4.
+                Some(DefaultValue::Actor) if actor.is_some() => actor.clone().unwrap(),
                 Some(DefaultValue::Str { value }) => SqlValue::Text(value.clone()),
                 Some(DefaultValue::Int { value }) => SqlValue::Integer(*value),
                 Some(DefaultValue::Float { value }) => SqlValue::Real(*value),
                 Some(DefaultValue::Bool { value }) => SqlValue::Integer(*value as i64),
-                None if field.optional => SqlValue::Null,
-                None => {
+                None | Some(DefaultValue::Actor) if field.optional => SqlValue::Null,
+                None | Some(DefaultValue::Actor) => {
                     let err = table
                         .error_for(ErrorKind::Required, &[&field.name])
                         .ok_or_else(|| ApiError::internal("missing derived required error"))?;

--- a/crates/spock-runtime/tests/graphql.rs
+++ b/crates/spock-runtime/tests/graphql.rs
@@ -340,7 +340,12 @@ async fn the_graphql_fns() {
     assert_eq!(resp["data"]["author_stats"]["posts"], 2);
 
     // -- many arity: the author owns LIMIT ------------------------------------
-    let resp = gql(&base, "query { recent_posts(n: 1) { caption } }", Value::Null).await;
+    let resp = gql(
+        &base,
+        "query { recent_posts(n: 1) { caption } }",
+        Value::Null,
+    )
+    .await;
     assert_no_errors(&resp);
     assert_eq!(resp["data"]["recent_posts"].as_array().unwrap().len(), 1);
 
@@ -355,7 +360,10 @@ async fn the_graphql_fns() {
     assert_eq!(resp["data"]["post_count"], 2);
     let resp = gql(&base, "query { captions }", Value::Null).await;
     assert_no_errors(&resp);
-    assert_eq!(resp["data"]["captions"], json!(["first light", "golden hour"]));
+    assert_eq!(
+        resp["data"]["captions"],
+        json!(["first light", "golden hour"])
+    );
 
     // -- one arity: the write returns the row ---------------------------------
     let resp = gql(
@@ -686,9 +694,7 @@ async fn the_graphql_mutations() {
     // -- composite by-pk query, then unfollow (the composite motivator) --------
     let resp = gql(
         &base,
-        &format!(
-            r#"{{ follow_by_pk(follower: "{luis_id}", target: "{maya_id}") {{ since }} }}"#
-        ),
+        &format!(r#"{{ follow_by_pk(follower: "{luis_id}", target: "{maya_id}") {{ since }} }}"#),
         Value::Null,
     )
     .await;
@@ -696,9 +702,7 @@ async fn the_graphql_mutations() {
     assert!(resp["data"]["follow_by_pk"]["since"].is_string());
     let resp = gql(
         &base,
-        &format!(
-            r#"{{ follow_by_pk(follower: "{maya_id}", target: "{luis_id}") {{ since }} }}"#
-        ),
+        &format!(r#"{{ follow_by_pk(follower: "{maya_id}", target: "{luis_id}") {{ since }} }}"#),
         Value::Null,
     )
     .await;
@@ -787,20 +791,45 @@ table follow {
 
     // field check: a bad username on the floor → user_username_invalid, and
     // the message names the validator fn
-    let resp = gql(&base, r#"mutation { insert_user_one(object: { username: "Bad Name!" }) { id } }"#, Value::Null).await;
-    assert_eq!(resp["errors"][0]["extensions"]["code"], "user_username_invalid");
+    let resp = gql(
+        &base,
+        r#"mutation { insert_user_one(object: { username: "Bad Name!" }) { id } }"#,
+        Value::Null,
+    )
+    .await;
+    assert_eq!(
+        resp["errors"][0]["extensions"]["code"],
+        "user_username_invalid"
+    );
     assert_eq!(resp["errors"][0]["extensions"]["kind"], "invalid");
-    assert!(resp["errors"][0]["message"].as_str().unwrap().contains("valid_username"));
+    assert!(resp["errors"][0]["message"]
+        .as_str()
+        .unwrap()
+        .contains("valid_username"));
 
     // a good one, and a second user for the row check
-    let a = gql(&base, r#"mutation { insert_user_one(object: { username: "maya" }) { id } }"#, Value::Null).await;
+    let a = gql(
+        &base,
+        r#"mutation { insert_user_one(object: { username: "maya" }) { id } }"#,
+        Value::Null,
+    )
+    .await;
     assert_no_errors(&a);
-    let id = a["data"]["insert_user_one"]["id"].as_str().unwrap().to_string();
+    let id = a["data"]["insert_user_one"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
 
     // row check: a self-follow on the floor → follow_follower_target_invalid
     let resp = gql(&base, &format!(r#"mutation {{ insert_follow_one(object: {{ follower: "{id}", target: "{id}" }}) {{ follower {{ id }} }} }}"#), Value::Null).await;
-    assert_eq!(resp["errors"][0]["extensions"]["code"], "follow_follower_target_invalid");
-    assert_eq!(resp["errors"][0]["extensions"]["fields"], json!(["follower", "target"]));
+    assert_eq!(
+        resp["errors"][0]["extensions"]["code"],
+        "follow_follower_target_invalid"
+    );
+    assert_eq!(
+        resp["errors"][0]["extensions"]["fields"],
+        json!(["follower", "target"])
+    );
 
     // the validator is an ordinary read fn on the Query root
     let resp = gql(&base, r#"{ valid_username(name: "noor.k") }"#, Value::Null).await;

--- a/crates/spock-runtime/tests/http.rs
+++ b/crates/spock-runtime/tests/http.rs
@@ -248,7 +248,10 @@ async fn me_default_stamps_the_actor_on_the_floor() {
     let forge = r#"mutation { insert_note_one(object: {owner: "luis", body: "x"}) { id } }"#;
     let body = gql_as(&base, Some("maya"), forge).await;
     let msg = body["errors"][0]["message"].as_str().unwrap_or("");
-    assert!(msg.contains("owner"), "expected owner rejected as unknown input, got {body}");
+    assert!(
+        msg.contains("owner"),
+        "expected owner rejected as unknown input, got {body}"
+    );
 }
 
 #[tokio::test]

--- a/crates/spock-runtime/tests/http.rs
+++ b/crates/spock-runtime/tests/http.rs
@@ -69,18 +69,7 @@ seed {
 
 /// Compile, materialize, serve on an ephemeral port; return the base URL.
 async fn start() -> String {
-    let contract = spock_lang::compile(PROGRAM).expect("program compiles");
-    let conn = engine::open(&contract, None).expect("engine opens and seeds");
-    let app = Arc::new(App::new(contract, conn));
-
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("bind ephemeral port");
-    let addr = listener.local_addr().expect("local addr");
-    tokio::spawn(async move {
-        http::serve(app, listener).await.expect("serve");
-    });
-    format!("http://{addr}")
+    start_program(PROGRAM).await
 }
 
 async fn get(base: &str, path: &str) -> (u16, Value) {

--- a/crates/spock-runtime/tests/http.rs
+++ b/crates/spock-runtime/tests/http.rs
@@ -190,6 +190,78 @@ async fn rpc(base: &str, name: &str, body: Option<Value>) -> (u16, Value) {
     (status, body)
 }
 
+// --- the actor seam (RFD 0014): a separate program with an `auth` anchor ---
+
+const ACTOR_PROGRAM: &str = r#"
+auth table account {
+  key handle: text
+  name: text?
+}
+table note {
+  key id: uuid = auto
+  owner: account = me
+  body: text
+}
+seed {
+  account { handle: "maya", name: "Maya Chen" }
+  account { handle: "luis" }
+}
+"#;
+
+async fn start_program(program: &str) -> String {
+    let contract = spock_lang::compile(program).expect("program compiles");
+    let conn = engine::open(&contract, None).expect("engine opens and seeds");
+    let app = Arc::new(App::new(contract, conn));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral port");
+    let addr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        http::serve(app, listener).await.expect("serve");
+    });
+    format!("http://{addr}")
+}
+
+async fn gql_as(base: &str, actor: Option<&str>, query: &str) -> Value {
+    let mut req = reqwest::Client::new()
+        .post(format!("{base}/graphql/v1"))
+        .json(&json!({ "query": query }));
+    if let Some(a) = actor {
+        req = req.header("X-Spock-Actor", a);
+    }
+    let resp = req.send().await.expect("POST graphql");
+    resp.json::<Value>().await.unwrap_or(Value::Null)
+}
+
+#[tokio::test]
+async fn me_default_stamps_the_actor_on_the_floor() {
+    let base = start_program(ACTOR_PROGRAM).await;
+    // owner is a reference, exposed as the `account` object (graphql.md D5)
+    let insert = r#"mutation { insert_note_one(object: {body: "hi"}) { owner { handle } body } }"#;
+
+    // impersonated → owner auto-stamped from the header, absent from the input
+    let body = gql_as(&base, Some("maya"), insert).await;
+    assert_eq!(
+        body["data"]["insert_note_one"]["owner"]["handle"], "maya",
+        "{body}"
+    );
+    assert_eq!(body["data"]["insert_note_one"]["body"], "hi");
+
+    // anonymous → the derived `required` error, not a raw 500 (§14.4)
+    let body = gql_as(&base, None, insert).await;
+    assert_eq!(
+        body["errors"][0]["extensions"]["code"], "note_owner_required",
+        "{body}"
+    );
+
+    // the `owner` field is off the client insert surface — a client cannot
+    // forge it (removed from note_insert_input; async-graphql rejects it)
+    let forge = r#"mutation { insert_note_one(object: {owner: "luis", body: "x"}) { id } }"#;
+    let body = gql_as(&base, Some("maya"), forge).await;
+    let msg = body["errors"][0]["message"].as_str().unwrap_or("");
+    assert!(msg.contains("owner"), "expected owner rejected as unknown input, got {body}");
+}
+
 #[tokio::test]
 async fn the_rpc_surface() {
     let base = start().await;

--- a/docs/rfd/0014-actor-seam.md
+++ b/docs/rfd/0014-actor-seam.md
@@ -1,0 +1,943 @@
+# RFD 0014 — The actor seam (identity milestone, slice 1)
+
+Status: **discussion draft**. A stance is recommended here; two decisions are
+left open for ratification (§11). This RFD proposes the *first* slice of the
+auth track (RFD 0009 track 7) — an actor context and dev-time impersonation —
+deliberately *without* roles or RLS, which stay v1. No implementation is
+proposed yet; this is the design record that a later milestone would build
+from.
+
+---
+
+## 0. The question
+
+Can a Spock prototype be *played as different users* — and can a `fn` body
+know *who is calling* — before the full auth/`policy` machinery exists? The
+demand is concrete and the doctrine already points at the answer; what was
+missing was the exact surface. This RFD settles it.
+
+Two framings were on the table, both from the same brief:
+
+1. **Conventional** — an explicit actor/role concept with an `impersonate`
+   affordance, so the prototype is playable and a `fn` can read the caller.
+2. **Unconventional** — declare `table user extends auth` and let *the
+   reference graph* decide ownership: whoever points at `user` (by key or
+   unique) becomes that user's "role-defining table," inferred rather than
+   declared.
+
+The recommendation keeps framing 1's *mechanism* and framing 2's *anchor
+instinct*, and **kills framing 2's inference** — for reasons that are doctrine,
+not taste (§6). The design was produced by a judged panel of four competing
+designs and hardened by an adversarial review; the review found two soundness
+defects in the panel's own winner, both folded in below.
+
+---
+
+## 1. What the dogfood proves (the pain is named: G12)
+
+`examples/instagram/v0.spock` threads identity as a **client-asserted
+parameter** through nearly every fn — `viewer: user`, `actor: user`,
+`author: user` — and checks it in raw SQL:
+
+```spock
+// today — the runtime believes whoever names `actor`. The guard is theater.
+mut fn delete_comment(comment: comment, actor: user) -> comment? {
+  unchecked sql("""
+    DELETE FROM comment WHERE id = :comment
+      AND (author = :actor OR :actor = (SELECT author FROM post WHERE id = comment.post))
+    RETURNING *
+  """)
+}
+```
+
+The file's own header says it: *"every fn below takes its actor as a
+client-asserted parameter (G12)."* This is two problems in one:
+
+- **Unsound.** A client passes any `actor` it likes and deletes anyone's
+  comment. Ownership guards across the file are decorative.
+- **Verbose.** `:viewer`/`:actor` is repeated in ~8 fns and every read that
+  wants a personalized answer (`home_feed`, `saved_posts`, `notifications`).
+
+And a third, quieter one: reads that *should* depend on the viewer structurally
+cannot. `post_comments` notes it can't show "visible, **or** held-and-mine"
+because it has no viewer; `search_profiles` can't exclude profiles that blocked
+the searcher. The missing actor is a *capability gap*, not only a soundness gap.
+
+## 2. How the design was chosen
+
+A four-way judged panel (doctrine / LLM-writability / forward-compat lenses)
+scored: **hybrid 59, minimal 57, `extends`-inference 46, explicit-roles 37**.
+The explicit-roles design was disqualified for shipping RLS-lite (an
+engine-injected `for <role>` precondition — "this is RLS") a full milestone
+ahead of the roadmap's auth-then-policy sequencing. The `extends`-inference
+design shipped the same clean core but buried it under a reference-graph→role
+scaffolder that overreaches doctrine (§6). The winner (hybrid) was then
+adversarially reviewed; the review confirmed the core is sound but found **two
+HIGH defects** in it — the nullability hazard (§4.4) and a `DIRECTONLY`
+category error (§4.2) — both corrected in this RFD, plus grafts from the other
+three designs.
+
+---
+
+## 3. The doctrine walls
+
+Any actor design must clear five fixed constraints already in the RFDs. They do
+most of the design work.
+
+| # | Wall | Source | Consequence here |
+|---|---|---|---|
+| W1 | **Deny by default; no inferred *source*.** *"inferred exposure makes the contract implicit again, which is the disease this language treats"* — with the escape *"intelligence is welcome at authoring time"* (the compiler may **scaffold** proposed source the author accepts). | RFD 0004 §1 | The anchor is *declared*, never inferred (§4.1). The reference-graph idea survives only as an authoring-time scaffold (§6). |
+| W2 | **Explicit actor context; no definer/invoker split, no confused deputy.** | RFD 0005 #4 | `spock_actor()` is the *invoker's* asserted identity, made available — never a runs-as-owner authority, and never leaked into a context it wasn't request-scoped for (§4.2). |
+| W3 | **Identity needs a consumer.** *"identity is inert until something consumes it"*; a fn-body binding is its **first** consumer, `policy` its **second**. | RFD 0009 track 7 | The seam lands *in fn bodies* first; the floor and reads-governance wait for v1. And the consumer cannot exist without the anchor (E-ACT03, §4.2). |
+| W4 | **Roles/RLS are v1.** `role`/`policy`/`view` are reserved-and-absent (spec §2.3, L005). | RFD 0002 §4, 0009 track 10 | No role taxonomy, no per-row governance, no `role` value on the wire in this slice (§10). |
+| W5 | **LLM-writability.** SQL-exact or radically simple; never a bespoke mini-grammar. | RFD 0013 | One anchor token; the seam is `spock_actor()`, the shape an LLM already writes as `auth.uid()`. No new rule grammar. |
+
+The banked auth architecture (RFD 0008 §4) supplies the shape: *"a header
+selecting the actor populates the same claims context a verified JWT later
+will; downstream code is identical … the swap is one resolver function."* This
+RFD is the v0 half of exactly that sentence.
+
+---
+
+## 4. The recommendation: the actor seam
+
+Four moving parts, each minimal. The whole milestone is *one scalar, made
+truthful*: relocate identity from "client argument" to "runtime-populated
+seam," changing nothing else about the SQL.
+
+### 4.1 The anchor — mark which table is identity
+
+One marker on the table that is the actor. **Recommended spelling: a prefix
+modifier, `auth table`** (parallel to `mut fn`), *not* `extends`:
+
+```spock
+auth table user {
+  key id: uuid = auto
+  username: text check valid_username unique
+  private: bool = false
+  joined_at: timestamp = now
+}
+```
+
+**What it means, exactly:** *this table's key is the actor identity.* Its key
+values are what `spock_actor()` returns, what the impersonation header names,
+and what a JWT `sub` will later carry. It is the app-side projection of the
+future builtin `auth.users` seam (RFD 0008 §4), named now so fn bodies and the
+claims seam have a binding target.
+
+**What it deliberately does NOT do** — the least-magic guarantees:
+
+- **Zero storage change.** No new column, no `auth.users` FK (v1), no DDL
+  difference. A pure contract marker.
+- **Zero roles, zero grants, zero predicate.** An anchor widens no reachability;
+  deny-by-default (W1) is untouched.
+- **Zero runtime scoping.** Nothing is auto-filtered by owner. The floor stays
+  actor-blind (§5). This is *declaration*, stating a fact the language cannot
+  today — *which table is the actor* — and nothing more.
+
+**Load rules (three new checks):**
+
+- **E-ACT01 — at most one anchor.** The actor space has one identity table.
+  (v1 may add other bases; v0 has exactly `auth`.)
+- **E-ACT02 — the anchor key is a single scalar column.** `spock_actor()`
+  returns one value; a composite-key anchor has no scalar identity — rejected
+  outright, not deferred. `key id: uuid` qualifies; a natural key
+  (`key handle: text`) makes `spock_actor()` return `text` (already works
+  end-to-end, dogfood C6).
+- **E-ACT03 — a consumer needs the identity** (§4.2).
+
+**Why `auth table`, not `table user extends auth`** (this reverses the
+originally-proposed spelling — see §11.A). The review and all three judge
+lenses converged on it:
+
+1. `extends` **connotes field inheritance** (TypeScript). The anchor inherits
+   *no* columns — an LLM writing `table user extends auth` will then write
+   `SELECT email FROM user WHERE id = spock_actor()` expecting an inherited
+   `email`, and `prepare()` fails "no such column." The token actively
+   mis-teaches — a direct W5 violation.
+2. `extends` is **spoken for by the role layer.** The vision draft
+   (`docs/rfd/0000-vision.spock`) already earmarks it for
+   `role post_author extends user` / `role user extends auth::user` — a
+   *different* semantic layer (a role refining a base) from "this table *is* the
+   identity." Spending `extends` on the anchor overloads it across two
+   client-facing layers with no room to disambiguate. **Names before bindings**
+   (RFD 0009): keep `extends` unspent for v1's roles.
+3. `auth table` is Spock's own established shape (`mut fn`, `auth table`) — a
+   *tag*, not inheritance.
+
+`auth` and `extends` should both be reserved in spec §2.3 the day this ships,
+so the choice is a decision, not an accidental grab.
+
+### 4.2 The seam — `spock_actor()`
+
+A fourth engine builtin alongside `spock_uuid()` / `spock_now()` /
+`spock_refuse()`. Zero-arg, returns the anchor key scalar, **NULL when
+anonymous**. This is the literal shape of the RFD 0008 §4 mirror target,
+`auth.uid()`:
+
+```spock
+mut fn delete_comment(comment: comment) -> comment? {
+  unchecked sql("""
+    DELETE FROM comment WHERE id = :comment
+      AND (author = spock_actor()
+           OR spock_actor() = (SELECT author FROM post WHERE id = comment.post))
+    RETURNING *
+  """)
+}
+```
+
+**It is invisible to fn-body load-validation** — the single strongest property.
+A scalar function call is an ordinary expression node, *not* a `:param` bind
+slot, so the both-directions "every `:param` is a declared parameter, every
+parameter is used" rule (spec §7.4) never sees it — exactly as it never sees
+`spock_now()`. **No new fn-body validation rule.**
+
+**Registration is DIRECTONLY, and gated on the anchor.** Two corrections to the
+naïve design, both load-bearing:
+
+- **DIRECTONLY — `spock_refuse`'s posture, NOT `spock_now`'s** (corrects a HIGH
+  defect). `spock_uuid`/`spock_now` are registered *non*-DIRECTONLY *on
+  purpose* — [engine.rs:111](../../crates/spock-runtime/src/engine.rs):
+  *"DEFAULT clauses must be able to call them."* They are stateless, safe
+  anywhere. `spock_actor()` is **request-scoped state**, correct *only* inside
+  a `func::call` where it is re-bound per request. Registering it
+  non-DIRECTONLY would let a floor `DEFAULT spock_actor()` or an
+  inline-expanded `CHECK(... spock_actor() ...)` (RFD 0013) evaluate it *outside*
+  `func::call` — against the connection-global closure still holding the *last*
+  fn caller's actor. On the single Mutex-serialized connection that is a
+  **cross-request confused deputy** (W2): an anonymous floor insert stamps rows
+  as whoever called last, and it silently corrupts RFD 0013's actor-blind-CHECK
+  determinism law. `spock_refuse` is already DIRECTONLY
+  ([engine.rs:123](../../crates/spock-runtime/src/engine.rs)) — *"a refusal is
+  a fn-body statement speaking; nothing indirect may raise"* — and works fine
+  inside read-fn SELECTs, which proves DIRECTONLY does **not** block top-level
+  fn bodies. `spock_actor()` takes the same posture: usable in every fn-body
+  read and write, loudly rejected in any DEFAULT/CHECK/trigger/view/
+  generated-column, which is precisely correct.
+- **Gated on the anchor (E-ACT03).** Register `spock_actor()` only when a table
+  is `auth`-marked. A body that calls it with no anchor then fails at
+  `prepare()` during load ("no such function"). *You cannot consume an actor
+  you never anchored* — W3 enforced mechanically, for zero extra lint code.
+
+**Per-request population — the "one resolver function."** The resolved actor
+threads into `func::call` (the shared execution primitive for REST
+`/rest/v1/rpc/{fn}` and every GraphQL fn root field), which re-binds the
+`spock_actor` closure to this request's value (NULL if anonymous) right before
+the transaction opens. Because there is exactly one serialized connection, the
+re-bind is race-free and the value is fixed for the fn's one serializable
+transaction (evaluated against pre-state, per RFD 0012). **Reads carry the
+actor symmetrically with writes** — one thread serves GraphQL Query fields and
+`GET /rest/v1/rpc/{fn}` alike; the polarity marker only picks the HTTP verb and
+transaction mode, never which builtins are callable.
+
+### 4.3 Impersonation — one knob: dev header + seed personas
+
+Impersonation is **not a second code path**. Following the cross-system lesson
+(PostgREST's role claim, Hasura's admin-secret + `x-hasura-role`, Studio's user
+picker), it is the *normal actor-carrying seam fed a value chosen by a trusted
+caller*. So v0 builds exactly one knob and refuses an `/impersonate` endpoint or
+a `spock run --as` flag.
+
+- **The header:** `X-Spock-Actor: <anchor-key>` — the actor's key value,
+  verbatim, **unverified in v0**. This *is* the future `sub`. Absent →
+  anonymous → `spock_actor()` NULL. Deliberately forgeable, honest about the
+  ungoverned prototype tier — not pretending to secure what a v1 signature will
+  secure.
+- **The resolver is anchor-key-type-aware** (corrects a LOW defect). It parses
+  and canonicalizes the header value by the anchor's key type exactly as
+  `path_key_value` already does for by-key GETs
+  ([http.rs](../../crates/spock-runtime/src/http.rs)) — so a `uuid` sent
+  uppercased or braced still matches the stored lowercase-canonical key. This
+  same resolver is the *one function* the v1 JWT swap replaces (it will verify
+  the signature and read `sub` instead of trusting the header).
+- **Seed personas — zero new syntax.** A persona in v0 is a seed row in the
+  anchor table; the dogfood already ships five (`maya`, `luis`, `noor`, …).
+  RFD 0002's "personas belong to seeds (role + identity)" degenerates cleanly,
+  in a role-free v0, to *identity only*. Seed still may not call fns and runs
+  before the listener binds, so `spock_actor()` is simply NULL through seed
+  replay, harmlessly.
+- **Two `~`-meta endpoints** (additive, next to `/~contract` and `/~health`):
+  - `GET /~personas` — the dev actor picker: the anchor table projected to
+    `[{ actor: <key>, label: <first unique text field, else key> }]`. Pick
+    `maya`, send her key in the header. Resolves "pick a known identity, don't
+    type a raw UUID" with no persona-name mini-grammar.
+  - `GET /~whoami` — the debugging primitive (the dev-tier mirror of GoTrue
+    `GET /user`): echoes `{ actor, anonymous, known }` where `known` = the key
+    exists in the anchor table. Answers "am I sending the header right?" and
+    "why does my guard match nothing?" — a typo'd key surfaces as
+    `known: false`. Never rejects.
+
+### 4.4 The nullability law — the swap is NOT text substitution
+
+This is the first HIGH defect the review found, and it changes how the milestone
+must be described. The client param `actor: user` was **required** (non-null);
+`spock_actor()` is **NULL for anonymous**. So the swap is *not* semantics-
+preserving, and "anonymous fails safe for free" is **false in general**:
+
+- **`= spock_actor()` guards** fail safe (anonymous matches no owned row — NULL
+  compares unequal). ✅
+- **Identity stored into a NOT NULL column** (`INSERT … author = spock_actor()`)
+  fails safe — an anonymous write trips the derived `<t>_author_required`. ✅
+- **Negation guards `x <> spock_actor()`** do **NOT** fail safe. `x <> NULL` is
+  NULL, not TRUE, so a `spock_refuse` gated on it *never fires* for anonymous.
+  The guard flips from "deny non-owners" to "**allow anonymous.**"
+
+The concrete escalation, which the naïve scaffolder itself would generate:
+
+```spock
+// add_to_collection, after a blind :actor → spock_actor() swap.
+// Anonymous caller (spock_actor() = NULL):
+//   not_owner guard:  (owner <> NULL) → NULL  → refusal NOT raised
+//   not_saved guard:  EXISTS(owner = NULL)    → false → refusal NOT raised
+//   the INSERT writes collection_post(collection, post) — NO actor column,
+//   so nothing trips NOT NULL.
+// ⇒ an anonymous, header-less request adds ANY post to ANY user's private
+//   collection. A real JWT does not fix this — the hole is the NULL branch,
+//   a first-class v0 state.
+```
+
+**The law:** an actor-consuming fn that must reject anonymous callers declares
+it, and the swap is audited per-fn, never applied blindly. The primitive is a
+one-line **authenticated-required guard** (grafted from the roles design), which
+needs nothing beyond this milestone:
+
+```spock
+unchecked sql("SELECT spock_refuse('unauthenticated') WHERE spock_actor() IS NULL")
+```
+
+Kind `refused`, 409 (RFD 0012 minted-refusal machinery, unchanged). This turns
+the silent no-op — the second MED defect (an anonymous
+`mark_notifications_read` returns `{rows:[]}` with 200, indistinguishable from
+"nothing was unread") — into a loud, honest refusal. A future `policy`/`for
+user` marker (v1) can make it declarative; v0 ships the primitive.
+
+### 4.5 The self-vs-object rule
+
+The swap replaces only the parameter that names *the caller* (the SELF side);
+parameters that name *another party* (the OBJECT side) stay parameters. The
+scaffolder (§6) and any author must respect this or they strip the wrong param:
+
+- `follow(follower, target)` → `follower` becomes `spock_actor()`; **`target`
+  stays** a param. `follow(target: user)`.
+- `approve_follow_request(requester, target)` → the *approver* is `target`, so
+  `target` becomes `spock_actor()`; **`requester` stays**.
+- `block_user(blocker, blocked)` → `blocker` → `spock_actor()`; `blocked` stays.
+
+### 4.6 Load-validation deltas — the complete list
+
+- **fn bodies calling `spock_actor()`: no change** (invisible to the `:param`
+  rule; polarity/`readonly` check untouched — a read fn may call it, as a read
+  fn already calls `spock_refuse`).
+- **The anchor:** E-ACT01 / E-ACT02 (§4.1).
+- **The consumer:** E-ACT03 (§4.2), enforced by conditional registration.
+- **Floor / auto-CRUD: unchanged, deliberately actor-blind** (§5).
+
+That is the whole delta: three anchor/consumer checks, and **nothing** added to
+the body-level `:param` rule.
+
+---
+
+## 5. What this deliberately does NOT do (and the honest framing)
+
+The floor — `GET /rest/v1/{table}`, GraphQL table roots, and the auto-CRUD
+mutations `insert_<t>_one` / `update_<t>_by_pk` / `delete_<t>_by_pk` — does
+**not** route through `func::call` and does **not** see `spock_actor()`. This
+is doctrine-aligned (spec §9 "no actor context yet"; W3 makes fn bodies the
+*first* consumer, policy the second). But it forces an honest reframing the
+panel's winner overclaimed (a MED defect):
+
+> **The seam is preparatory, not protective, in v0.** Making a fn's ownership
+> guard *sound* provides **zero v0 security benefit** while a byte-for-byte
+> bypass sits next to it. `add_comment` may store `author = spock_actor()` so
+> "the client cannot forge authorship" *through the fn* — but an attacker
+> ignores the fn and calls `insert_comment_one(object: {author: VICTIM, …})` on
+> the open floor. G12's **unsoundness inside the deliberate surface** is what
+> retires; the floor stays ungoverned until v1 `policy` re-derives it per actor.
+
+Two consequences for how the RFD (and any future contract) must talk:
+
+- **No "G12 retired" claim.** Say: *G12's unsoundness inside the fn surface is
+  retired; the floor remains an ungoverned bypass by decision (spec §9).*
+- **A dark-write ledger** (grafted from roles, serving RFD 0004 §7's
+  surface-as-data): the contract/introspection should surface, per
+  identity-bearing table, a *"⚠ ungoverned floor write — no guard"* row — so the
+  real attack surface (the floor bypass) is reviewable as data, not just the
+  governed fns. This pre-stages the v1 `role × field × read/write × via` ledger
+  and stops the seam from *advertising* a soundness the floor negates.
+
+---
+
+## 6. The unconventional idea, adjudicated
+
+> *"define a table as `user extends auth` and whoever uses `user` as pk or
+> unique automatically becomes that user's role-defining table."*
+
+**The anchor instinct is right and is kept** (§4.1) — declaring *which* table is
+identity is exactly the missing fact. **The inference is wrong and is killed.**
+Three doctrine kills plus empirical undecidability:
+
+- **W1 (no inferred source).** A role/ownership map derived from FK shape *is*
+  the contract inferred from structure — "the disease this language treats."
+  RFD 0004 §1's escape licenses scaffolding *implementation from a stated
+  policy*, not *policy from graph shape*.
+- **W2 (confused deputy) / W5 (LLM-writability).** A rule you cannot see is a
+  rule you cannot audit or write.
+- **It is undecidable on the real dogfood.** The reference graph does not encode
+  ownership unambiguously:
+  - `post.author` / `comment.author` are **not key members**, so a "PK/unique
+    reference" rule *misses the two most obvious owners*.
+  - `follow(follower, target)`, `block(blocker, blocked)`,
+    `restriction(restricting, restricted)` have **two co-equal user refs** in
+    the key — which owns? And inferring the *second* (`block.blocked`) would
+    **leak the block-list to the blocked party**.
+  - `mention.profile`, `media_tag.tagged`, `report.profile` name the **subject**,
+    not the actor — inferring ownership there *inverts* it.
+  - `follow_request` "ownership" depends on the **operation** (request vs
+    approve), not the row.
+  - `collection_post` has **zero** user refs.
+
+**The salvage — the only doctrine-legal home for the instinct** — is an
+**authoring-time scaffold** (W1's escape), which *proposes* source the author
+commits, never runtime behavior. Grafted from the `extends`-design's classifier,
+with a concrete four-way disposition per ownership-candidate edge:
+
+| Disposition | When | Example |
+|---|---|---|
+| **clean-propose** | one unambiguous self-ref | `post.author` → propose the `spock_actor()` guard |
+| **transitive-propose** | ownership one hop away | `media_tag` via `media.post.author` |
+| **surface-with-flag** | plausible but risky | flag, don't auto-accept |
+| **refuse-with-reason** | accepting would leak or invert | *decline* `block.blocked` and **say in the diff**: "proposing this owner leaks the block-list to the blocked party" |
+
+The narrow slice **v0 can actually ship** (because it needs no `policy` to emit
+into) is a lint + rewrite proposal:
+
+- **L-ACTOR** — a fn param typed as the anchor table (`actor:`/`viewer:`/
+  `author: user`) compared to an ownership column is flagged: *"this identity is
+  client-asserted (G12); it can be forged."*
+- The scaffold proposes the §4 rewrite (drop the param, `:actor` →
+  `spock_actor()`, respecting the self-vs-object rule §4.5), delivered as a
+  **git diff the author reviews and commits** (the `terraform plan` tradition,
+  RFD 0004 §5/§7) — "the language proposes; the author confirms."
+
+The full ownership-*policy* scaffolder (proposing `policy`/guards) needs
+`policy` to emit into, so it is **v1**. What ships of the unconventional idea in
+v0: the *declared* anchor, and the G12 lint + `spock_actor()`-swap proposal.
+The inferred role-defining table is killed with no salvage.
+
+---
+
+## 7. The dogfood, before → after
+
+**`delete_comment` — the canonical soundness fix** (§1's example): the param
+vanishes, the predicate is identical modulo `:actor` → `spock_actor()`, and the
+"author-or-post-owner may delete" rule is finally *true* rather than asserted.
+
+**`home_feed` — a read gains a viewer it structurally lacked:**
+
+```spock
+// AFTER — :viewer → spock_actor(); reads carry the actor with zero new plumbing
+fn home_feed(before: timestamp?) -> [feed_item] {
+  unchecked sql("""
+    SELECT p.id AS post, u.username AS author, p.caption, p.published_at,
+      (SELECT count(*) FROM "like"   WHERE post = p.id) AS likes,
+      (SELECT count(*) FROM comment  WHERE post = p.id AND status='visible') AS comments,
+      EXISTS(SELECT 1 FROM "like" WHERE post = p.id AND user = spock_actor()) AS viewer_liked,
+      EXISTS(SELECT 1 FROM save   WHERE post = p.id AND user = spock_actor()) AS viewer_saved
+    FROM post p JOIN user u ON u.id = p.author
+    WHERE (p.author = spock_actor()
+           OR EXISTS (SELECT 1 FROM follow WHERE follower = spock_actor() AND target = p.author))
+      AND NOT EXISTS (SELECT 1 FROM block
+                      WHERE (blocker = spock_actor() AND blocked = p.author)
+                         OR (blocker = p.author AND blocked = spock_actor()))
+      AND p.archived_at IS NULL
+      AND (:before IS NULL OR p.published_at < :before)
+    ORDER BY p.published_at DESC, p.id DESC LIMIT 20
+  """)
+}
+```
+
+Anonymous (NULL) sees an empty personalized feed and `false` viewer flags — the
+correct anonymous behavior, no error. And the upside the seam unlocks:
+`search_profiles` can finally exclude profiles that blocked the searcher;
+`post_comments` can show "visible **or** held-and-mine" — reads that were
+impossible without a viewer.
+
+**`add_comment` — identity into a stored column, safely:** `:author` →
+`spock_actor()` including the written `author` column, so the client can no
+longer forge authorship *through the fn*; an anonymous write trips
+`comment_author_required`.
+
+**`add_to_collection` — the cautionary tale (§4.4):** this fn must gain the
+`unauthenticated` guard, because a blind swap turns it into an anonymous
+privilege escalation. It is the proof that the swap is per-fn audited, not
+mechanical.
+
+Across the file the swap retires ~8 client-asserted identity params — visible in
+the contract *diff* as parameters disappearing (surface-as-data, RFD 0004 §7).
+
+---
+
+## 8. Contract-JSON additions (additive, `#[serde(default)]`)
+
+- **The anchor marker on the identity table** — `Some("auth")` on the anchor,
+  absent elsewhere; typed `Option<String>` (not `bool`) for forward-compat with
+  v1 bases. Marks which table is the actor so generators, introspection, and the
+  future ledger know. `spock_actor()`'s return type needs no field — it is the
+  anchor's key type, derivable by any consumer.
+- **`reads_actor` (an "is this fn actor-dependent" bit): recommended DEFERRED.**
+  The panel proposed it, but the review is right that its *derivation* is
+  net-new and the only cheap implementation is a substring scan for
+  `spock_actor` — which false-matches a string literal or a comment and
+  contradicts the codebase's "no vocabulary scan" ethos
+  ([func.rs](../../crates/spock-runtime/src/func.rs)). Ship it only with a
+  robust derivation (walk the prepared statement's referenced-function set), or
+  not at all. A fragile bit in a *frozen* contract is worse than no bit.
+
+Everything else is additive: fns shed params (shorter `params` list); no
+existing field changes shape.
+
+---
+
+## 9. Forward-compat
+
+**Into v1 `policy`/RLS.** `spock_actor()` *is* the substrate `policy`
+re-derives over (RFD 0009: same derivation, run per role). The vision's
+`role post_author extends user on model::post { check: .author }` compiles to a
+predicate comparing `author` to `spock_actor()`. Policy is added *around* the
+seam, not in place of it — no rework; pre-state evaluation and barrier-ordering
+are policy-engine concerns layered on an inert seam. The dark-write ledger (§5)
+pre-stages the per-role surface table.
+
+**Into the GoTrue mirror (signup/login fills the same seam).** When the ~5
+endpoints land and `auth.users` becomes a builtin:
+
+- The anchor table FK-ties to `auth.users.id` (the `sub`), or becomes a view
+  over it — `auth`-marking is where that tie attaches. Projection semantics to
+  specify then: `email` read-only (`@protected`), credential never projected,
+  profile columns author-owned.
+- `Authorization: Bearer <JWT>` replaces `X-Spock-Actor`; the resolver verifies
+  the signature and reads `sub`. **`spock_actor()` and every fn body are
+  byte-identical across the swap** — only §4.3's `resolve_actor` changes.
+  `~whoami` becomes GoTrue's `GET /user`; the dev header survives as a
+  dev-flag-gated override (Hasura-style).
+- The `role` claim arrives on the same token → feeds `spock_role()`/`policy`
+  (v1). Auth-gated lifecycle states (`banned`, `verified`) arrive *with* the
+  transitions that reach them — this slice adds no unreachable states.
+
+Sequencing check (RFD 0009's four rules): **names before bindings** — the seam
+names match the `auth.uid()`/`sub` world so they don't churn, and no unused
+`role` name ships early; **borrow before build** — the header→claims seam is
+Hasura/PostgREST, `spock_actor()` is `auth.uid()`, GoTrue is borrowed later;
+**language work is the differentiator** — the differentiator (`policy` as
+named/testable/composable guards) is correctly held for v1; **identity needs a
+consumer** — this lands exactly at track 7's first consumer.
+
+---
+
+## 10. Deferrals — every one named
+
+1. **Role taxonomy** — `role`, `policy`, `spock_role()` stay reserved/absent (v1).
+2. **No unused `role` value on the wire in v0** — a client-facing scalar nothing
+   consumes is a name scheduled for meaning (violates names-before-bindings).
+   Add it *with* policy.
+3. **JWT verification + GoTrue endpoints** — v1. The v0 header is deliberately
+   forgeable.
+4. **`auth.users` builtin table** — v1. v0's anchor is the app's own table.
+5. **Floor / auto-CRUD actor governance** — v1 policy (§5). v0 floor is
+   actor-blind by decision.
+6. **The ownership-*policy* scaffolder** (proposes `policy`/guards) — v1; needs
+   `policy` to emit into. v0 ships only the G12 lint + swap proposal (§6).
+7. **Per-row conditional field projection** (owner-sees-email, G12's projection
+   half) — v1 (views/policy).
+8. **Named waivers / `service_role` bypass** — v1; nothing to bypass until
+   policy exists.
+9. **Composite-key anchor / tuple actor** — rejected outright (E-ACT02), not
+   deferred.
+10. **`reads_actor` contract bit** — deferred pending a robust derivation (§8).
+11. **OAuth/OIDC, multi-actor act-as, auth-gated lifecycle states** — v1+.
+
+---
+
+## 11. Open questions (for ratification)
+
+**A. The anchor keyword — `auth table user {}` (recommended) vs the originally
+proposed `table user extends auth`.** §4.1 argues hard for the prefix modifier
+(no inheritance mis-signal, `extends` kept free for v1 roles, Spock's own
+`mut fn` shape). The counter-argument for `extends`: it is familiar and reads
+naturally. This reverses a spelling the brief proposed, so it is explicitly the
+author's call. A third option — `auth user { … }` (dropping `table`, since the
+anchor is always a table) — is more novel but loses the "it's a normal table,
+just tagged" read. **Recommendation: `auth table`.**
+
+**B. Ship the `unauthenticated` guard as a raw idiom, or as a marker?** §4.4's
+one-line `spock_refuse('unauthenticated') WHERE spock_actor() IS NULL` needs no
+new surface and ships today. A declarative `for user` / `requires actor` marker
+is cleaner but edges toward the role layer (W4). **Recommendation: raw idiom in
+this slice; revisit the marker with `policy`.**
+
+**C. Roadmap placement.** The plan of record (RFD 0009 §3) sequences full auth
+*after* the filter RFD. This slice is far lighter than full auth — one builtin,
+one marker, one header — and it is what makes every `fn` guard the dogfood
+already wrote actually *true*. It could land before the filter RFD (as fn v2 and
+the value tier did, on dogfood evidence) or stay after. **Recommendation:
+decide against the four ordering rules, not the sequence** — the honest read is
+that the seam is *preparatory* (§5), so its urgency is lower than the filter
+layer's, which unblocks real read/write breadth. Likely: **after** the filter
+RFD, still before v1 policy.
+
+**D. Secrecy tables on the open floor** (raised by the RLS cross-check, §13.4).
+`block` / `restriction` / `follow_request` are the one family the harness cannot
+even *partly* rescue in v0: a table whose row's *existence* is the secret leaks
+wholesale on `GET /rest/v1/block`, and no fn un-leaks it. Options: (a) accept it
+as the ungoverned-tier decision (spec §9) and ship a **loud lint** naming each
+secret-bearing floor table; (b) add a minimal **not-floor-exposed** table marker
+(deny-by-default reads for sensitive tables) — small and W1-aligned, but it
+edges toward the v1 governance flip. **Recommendation: the lint now; the marker
+weighed with `policy`.** This is the only point where the cross-check pushes back
+on "the floor stays fully open by decision."
+
+---
+
+## 12. What ships, in one paragraph
+
+One keyword (`auth table`), one DIRECTONLY builtin (`spock_actor()`, NULL when
+anonymous, registered only when an anchor exists), one runtime-minted default
+(`= me`, the write/population half — §14: a strong Hasura-style preset removed
+from the client insert/update surface, so the floor auto-stamps the actor and no
+client can forge it), one forgeable dev header (`X-Spock-Actor`) resolved
+anchor-key-type-aware against committed seed personas, two `~`-endpoints
+(`/~whoami`, `/~personas`), a per-request actor threaded into `func::call` and
+the floor insert, the anchor/consumer checks (E-ACT01–03) plus the E016 `me`
+carve-out and E022 seed tightening, additive contract markers, and one
+authoring-time G12 lint/scaffold. Zero new fn-body validation rules. The
+prototype can be played as maya, luis, noor, or anonymous; identity columns are
+server-stamped and unforgeable on the floor via `= me`; every ownership guard
+inside the deliberate fn surface becomes *sound*; and the rest of the floor
+stays an ungoverned bypass **by decision**, surfaced as data, until v1 `policy`
+governs it. The reference-graph "infer the roles" instinct lives on only where
+doctrine allows it — as a diff the author commits, never a rule the runtime
+guesses.
+
+---
+
+## 13. The RLS cross-check (second harness)
+
+The adversarial review (§2) was the first harness. The second is differential
+(the RFD 0005 method — Postgres as the oracle): write the same product as a
+**Supabase-native RLS schema** — where auth *is* ready and RLS *is* the
+authorization layer — and cross-check every policy against this seam. The oracle
+is [`examples/instagram/pg-rls.sql`](../../examples/instagram/pg-rls.sql): 59
+policies over 22 tables plus a small enterprise RBAC addendum
+(`organization` / `membership(role)` / `org_setting`), hardened by a Postgres
+pedant (anti-recursion `SECURITY DEFINER` helpers in a non-exposed `private`
+schema; per-command `USING`/`WITH CHECK`; the admin→owner escalation closed).
+
+**Why this oracle, and what it measures.** The two Postgres *styles* map onto
+Spock's two *surfaces*. The existing `examples/instagram/pg.sql` — "an API of
+`SECURITY DEFINER` functions, RLS as defense in depth" — is Spock's **deliberate
+fn surface** (the guard lives in the function). Supabase's "RLS on
+directly-hit tables" is Spock's **floor + v1 `policy`** (the guard lives in
+per-row policy on the table the client hits). The actor seam sits between them:
+it makes the *function-style* guard sound (`spock_actor()` = `auth.uid()`), and
+leaves the *RLS-style* floor governance to v1. So cross-checking against the
+Supabase file measures exactly how much of "RLS-as-authorization" the v0 seam
+reaches. Every policy was judged on **two axes**: (A) *expressibility* — can the
+seam state the predicate with `spock_actor()` + SQL in a fn? (B) *enforceability
+in v0* — is it actually enforced, given the floor stays an open, actor-blind
+bypass? Each verdict was then adversarially verified (rescue-a-CANNOT /
+demote-a-FITS).
+
+### 13.1 The result — the boundary is *one gap*
+
+| | count | reading |
+|---|---:|---|
+| **Expressible** with `spock_actor()`+SQL | **58 / 59** | the seam's predicate vocabulary is already sufficient |
+| **Enforceable in v0** | **4 / 59** | almost nothing is *enforced*, because the floor is open |
+| — of which need only the floor closed (`floor-governance` gap) | **54** | one gap, not many |
+| — need a capability beyond the seam (`jwt-claims`/roles) | **1** | the sole true capability gap |
+
+Verdicts (post-verify, 0 flipped): **FITS 2 · TRICK 54 · CANNOT 3.** The TRICK
+bucket splits 18 reads / 36 writes.
+
+The single most telling line: **the only two policies that FIT are the two that
+need no governance at all** — the `USING true` public reads (`location`,
+`hashtag`), where the open floor *is* the policy. Everything that actually
+*governs* is TRICK or worse. That is §5's "preparatory, not protective," now
+measured: of 59 real policies, the seam soundly enforces the 2 that ask for
+nothing.
+
+### 13.2 The three piles
+
+- **FITS (2)** — `location_read`, `hashtag_read`: `USING true`. `spock_actor()`
+  is never even invoked; `GET /rest/v1/location` already *is* `TO anon USING
+  true`. The floor being open is *correct* here.
+
+- **TRICK (54) — expressible, but the open floor leaks.** Two shapes:
+  - *Writes (36).* The `:actor` → `spock_actor()` swap makes the sanctioned fn
+    path sound (`INSERT INTO post(author,…) VALUES(spock_actor(),…)`), NULL-safe
+    against anonymous. **But** `insert_post_one(object:{author: VICTIM})` on the
+    floor forges authorship regardless — the §5 archetype, confirmed policy by
+    policy. The fn is sound; the floor next to it is the hole.
+  - *Reads (18).* A read fn carries the viewer and even preserves Postgres's
+    *forbidden ≡ not_found* (a blocked viewer's `profile(username)` returns
+    `not_found`, no existence leak). **But** `GET /rest/v1/post` /
+    `/rest/v1/follow` still serve archived posts, private-authored posts, and the
+    entire follow graph actor-blind. The fn adds a governed *view*; it cannot
+    subtract the floor's ungoverned one.
+
+- **CANNOT (3) — genuinely out of v0's reach**, and instructively of two kinds:
+  - `block_read`, `restriction_read` — **secrecy reads.** A read fn *can* state
+    "my blocks" (`WHERE blocker = spock_actor()`), but it is a **non-solution**:
+    the whole content of the policy is secrecy, and the `block` table sits on the
+    open floor, so `GET /rest/v1/block` publishes every block to everyone. When
+    the leak *is* the vulnerability, no fn rescues it — it needs floor read-
+    governance (v1). This is the one place the harness argues a v0 slice is not
+    merely "preparatory" but actively *misleading* if shipped alone (see 13.4).
+  - `report_read_moderator` — the **only capability gap**: it reads a signed JWT
+    claim (`auth.jwt() -> app_metadata ->> role = 'moderator'`). The seam exposes
+    exactly one identity fact — `spock_actor()`; there is no `auth.jwt()`, no
+    `spock_role()`, no claims map in v0 (W4). Not expressible at all — v1.
+
+### 13.3 What it validates about the seam
+
+1. **§5, quantified.** 54 of 59 policies fail on a *single* axis — the open
+   floor — not on expressibility. The seam is preparatory, not protective, and
+   now we know the exact ratio.
+2. **§9 forward-compat, strongly.** 58/59 expressible means the seam is the
+   **right substrate**: the `spock_actor()` predicates authors write in fns
+   *today* are the same predicates v1 `policy` will hoist onto the floor. v1
+   policy is not a redesign — it is "apply these predicates to the floor" plus a
+   claims/role seam. The cross-check is direct evidence for §9's "`spock_actor()`
+   *is* the substrate `policy` re-derives over."
+3. **The v1 scope, sharpened.** Beyond floor-governance there is exactly **one**
+   missing capability: roles / JWT claims (1 of 59). Everything else v1 policy
+   needs, the actor seam already carries.
+
+### 13.4 What it surfaces as new design input
+
+- **A named visibility predicate fn (cheap v0 win).** The verifier flagged that
+  `can_view_post` is re-inlined across six read policies (`post`, `media`,
+  `like`, `comment`, `mention`, `post_hashtag`). A shared, checker-owned
+  `fn can_view_post(post) -> bool` — the RFD 0013 validator-fn / named-callable-
+  predicate shape — would DRY the dogfood, is client-pre-flightable, and composes
+  into every read. This is the "graft named predicates from the roles design"
+  idea (§2 grafts), now independently rediscovered with evidence. Worth adopting
+  *with* or before this slice.
+- **Secrecy tables want off the open floor.** The `block` / `restriction` /
+  `follow_request` CANNOTs are the sharpest finding: for a table whose *existence*
+  is the secret, an fn cannot un-leak what the floor publishes. This is a
+  concrete argument that even the v0 slice may need a way to mark a table
+  **not-floor-exposed** (deny-by-default reads for sensitive tables) — a small,
+  doctrine-aligned (W1) addition — or at minimum a **loud lint**: "table `block`
+  is on the open floor and its rows are a secret." Recorded as a candidate, not
+  folded into the slice (it edges toward the governance flip); it is the one
+  place the harness pushes back on "floor stays fully open by decision."
+- **Confirmations.** The `unauthenticated` guard (§4.4) is exercised by the
+  write policies (anonymous inserts fail safe via NOT NULL or the guard);
+  *forbidden ≡ not_found* (Postgres P27) is preserved by the read-fn pattern.
+  Both design choices survived the cross-check.
+
+### 13.5 Bottom line
+
+The RLS harness **validates the seam as the correct substrate and refutes it as
+an authorization mechanism** — exactly the honest split §5 claims. 58/59 policies
+are sayable with `spock_actor()`; 54 are unenforceable only because the floor is
+open (v1 closes them with the same predicates); 2 fit because they govern
+nothing; 3 genuinely cannot — 2 secrecy-reads that need floor read-governance,
+and the 1 true capability gap (roles/claims). It also hands v1 its scope on a
+plate — floor governance + a claims/role seam — and hands v0 one cheap win (the
+named visibility predicate) and one open question (secrecy tables on the open
+floor, §11.D).
+
+---
+
+## 14. The population seam — `= me` (the write half)
+
+§4.2's `spock_actor()` is the *read* half of identity: it makes a fn's guards
+sound. This section is the *write* half, and it is the more ergonomic one — the
+Supabase `author uuid default auth.uid()` move, where data flows *from* identity
+automatically. In Spock: **`author: user = me`**. It is a self-contained
+primitive — it works, and is worth having, with RLS entirely set aside.
+
+### 14.1 Surface & symmetry — `me` joins `auto`/`now`
+
+A third runtime-minted default keyword, bare, next to `auto` and `now`. The
+mapping is clean and total: each default keyword is backed by an engine builtin.
+
+| default | mints | builtin |
+|---|---|---|
+| `auto` | a UUIDv7 | `spock_uuid()` |
+| `now` | the UTC instant | `spock_now()` |
+| **`me`** | **the current actor's key** | **`spock_actor()`** |
+
+`me` is legal only on a field that is a **reference to the `auth`-anchored actor
+table** (`author: user = me` where `user` is `auth`-marked, §4.1); on a non-actor
+field, or with no anchor declared, it is a compile error. One real obstacle: the
+checker rejects *any* default on a reference field today (E016,
+[check.rs](../../crates/spock-lang/src/check.rs)) — E016 must gain a carve-out
+for exactly this case (`me` on an anchor-typed ref). That carve-out is the only
+non-mechanical part of the change.
+
+### 14.2 Strong, not weak — `me` leaves the client's write surface
+
+The decisive design choice, and the peer survey is unanimous on it. Two forms
+were on the table:
+
+- **Weak** (the `auto`/`now` shape): populate-when-absent, but *client-
+  overridable* — a client may still send `author: VICTIM`. This is Supabase's
+  `DEFAULT auth.uid()`, which is only safe **paired** with a `WITH CHECK (author
+  = auth.uid())` RLS policy. Spock has no such pairing in v0.
+- **Strong** (Hasura's "column preset from a session variable"): the field is
+  *removed from the client write surface entirely* — absent from
+  `<t>_insert_input` **and** `<t>_set_input` — so a client cannot name it at all.
+
+**Recommendation: the strong form.** Every system that *can* structurally remove
+an identity column from client input does so; every system that instead defaults
+it treats the default as one half of a mandatory two-piece mechanism, and ships
+the other half (a CHECK/policy) with it. Spock has no near-term other half (that
+is v1 `policy`), but it *does* have the generated-schema machinery to remove the
+field cheaply and correctly today. So `me` is a **preset, not a default** — and
+that is the one piece of §5's "the floor stays open by decision" that does **not
+have to stay open**: a client cannot forge a `me` column on the floor, because
+the column is not in the floor's input.
+
+The asymmetry with `auto`/`now` (which stay in the input, overridable) is
+principled, not arbitrary: a client may legitimately supply an id or a timestamp
+(an import, a backfill); a client *asserting identity* is forgery, always.
+Mechanically, `insert_input_type` / `set_input_type`
+([graphql.rs:352](../../crates/spock-runtime/src/graphql.rs)) skip
+`me`-default fields, and async-graphql's schema validation then rejects any
+object carrying one as an unknown input field **before the resolver runs**
+(verified against async-graphql v7 on both literal and variable paths).
+
+### 14.3 Mechanism — runtime-materialized, DIRECTONLY-safe, no drift
+
+`me` is materialized on the **write path** in Rust, exactly where the floor
+already mints `auto`→`new_uuid()` and `now`→`now_utc()`
+([write.rs:39](../../crates/spock-runtime/src/write.rs)) — the arm gains
+`Some(DefaultValue::Actor) => …the request actor…`. It is **not** a DDL `DEFAULT`
+clause, because `spock_actor()` is DIRECTONLY (§4.2) and cannot appear in one.
+
+A pleasant structural consequence falls out: **the floor never *calls* the
+DIRECTONLY builtin at all** — it passes a pre-resolved Rust value into the
+insert — so it sidesteps by construction the confused-deputy hazard DIRECTONLY
+exists to prevent. The floor becomes actor-*aware* without ever *evaluating*
+`spock_actor()`. And there is one source, so **no drift**: the floor
+materializes the request actor in Rust; an escape's `INSERT … VALUES(spock_actor(),
+…)` evaluates the builtin, which `func::call` re-binds to the *same* request
+actor (§4.3's one resolver). Both read one value.
+
+**The wiring must be per-request — this is the trap the stress pass caught.**
+The actor value has to be injected *per request*, via async-graphql's
+`schema.execute(request.data(actor))` (read back with `ctx.data::<Actor>()`),
+with `graphql_post` gaining the same `X-Spock-Actor` `HeaderMap` extractor §4.3
+adds. It must **not** ride the schema-global `.data(Arc<App>)` channel
+([graphql.rs:285](../../crates/spock-runtime/src/graphql.rs)) — that is set once
+at startup and shared by every request, so a request with no header would read
+the *previous* caller's actor and stamp their identity: the exact §4.2 cross-
+request confused deputy, reintroduced on the newly actor-aware floor. Per-request
+`Request::data`, never schema-builder `.data`, for the actor.
+
+### 14.4 Every path, and the two corrections the stress pass forced
+
+- **Floor insert.** The client omits the `me` column (it isn't in the input);
+  the runtime stamps the request actor. `insert_post_one(object: {caption})`
+  yields a post authored by the caller.
+- **Anonymous → the derived `required` error, NOT a 500** (corrected HIGH). A
+  required `me` column with no actor must route to `<t>_<field>_required` (422).
+  The naïve arm (materialize `NULL` → hit engine `NOT NULL`) instead surfaces a
+  raw `SQLITE_CONSTRAINT_NOTNULL` that the floor's `map_conflict_error` does not
+  translate → **HTTP 500**, while the *escape* path's `map_fn_engine_error` maps
+  the same `NOT NULL` to the 422 — a real floor-vs-escape drift, refuting a
+  first-draft "no drift" claim. Fix: when the resolved actor is `None` and the
+  field is non-optional, `write.rs` emits the derived `required` error directly
+  (like its existing required path), never pushing `NULL`. Net effect: an
+  anonymous, header-less floor insert of an owned row **cannot happen** — it must
+  assert an identity. (Fail-safe, aligning §4.4.)
+- **Seed — anonymous at seed time, must name `me` explicitly** (E022 tightening).
+  Seed runs before the listener binds, so the actor is `NULL` through replay, and
+  seed enters `write.rs` *directly* (bypassing the GraphQL input filter) — so,
+  unlike a client, it *may and must* name the `me` column to author fixtures.
+  E022 must treat an `Actor` default as *no default for seed purposes* so the
+  checker **demands the column in every seed row at load time**, rather than
+  aborting at replay on `NOT NULL`. This is the same authoring-tier bypass every
+  preset system has (Hasura admin, Postgres `service_role`) — named, not
+  invented.
+- **Updates — stamped once, immutable.** Defaults never re-apply on update, so an
+  omitted `me` column keeps its author for free; and removing it from
+  `set_input` (§14.2) stops a later editor from *re-stamping* ownership to
+  themselves. **Guard the degenerate case** (corrected HIGH): `has_settable_fields`
+  ([graphql.rs:301](../../crates/spock-runtime/src/graphql.rs)) does not inspect
+  defaults, so a table whose only non-key field is `= me` would generate an
+  **empty `_set` input object** — invalid GraphQL, the server fails to boot.
+  `has_settable_fields` (and the insert-input emptiness guard) must exclude
+  `Actor`-default fields.
+- **Escapes name `spock_actor()`.** With no DDL DEFAULT for `me`, an escape that
+  omits the column gets no auto-fill; the author writes `spock_actor()` (the §5.3
+  pattern) — same value, no drift.
+- **The actor must exist as an anchor row.** The floor `me` stamp is ref-checked
+  like any reference, so a header naming a key absent from the anchor table
+  (`~whoami`'s `known: false`) yields `ref_not_found`, not a dangling author.
+  Correct: you cannot author as a user who does not exist.
+
+### 14.5 The dogfood, before → after
+
+```spock
+// BEFORE — author is client-supplied; insert_post_one(object:{author: VICTIM})
+// forges authorship on the open floor.
+table post { key id: uuid = auto  author: user  caption: text?  … }
+
+// AFTER — author leaves post_insert_input; the floor auto-stamps the caller,
+// and no client can name it. The ~8 fns that threaded `author:`/`actor:` shed
+// the param (§5) AND the floor stops accepting a forged author for free.
+table post { key id: uuid = auto  author: user = me  caption: text?  … }
+```
+
+`comment.author`, `collection.owner`, `save.user`, `like.user`,
+`report.reporter`, `media_tag.tagged` (the tagged-self case), `block.blocker`,
+`follow.follower` are the same shape — the "self" side of each. (The "object"
+side — `follow.target`, `block.blocked` — stays a normal client field; §4.5's
+self-vs-object rule applies to the write seam too, and a checker guard should
+keep `= me` to the self side.)
+
+### 14.6 The stance shift, and its exact bound
+
+This makes the floor **actor-aware for population** — a real change from §5/§6's
+"actor-blind floor." It is doctrine-safe because population is **provenance, not
+governance**: `= me` makes no allow/deny decision, applies no predicate, filters
+no row — it fills a column. W3 orders identity's *governance* consumers (fn body,
+then `policy`); population is a third kind, orthogonal to that ordering, so it
+does not front-run `policy`.
+
+But state the win at its true size, no larger: `= me` **closes the floor-forge
+for the identity column it marks** — a bounded, real gain (an attacker can no
+longer set `author` on `insert_post_one`). It does **not** make the floor safe:
+every *other* floor write and every floor read stays ungoverned (that is still
+v1). "Identity columns become server-stamped and unforgeable on the floor" is the
+honest headline — not "G12 is closed."
+
+### 14.7 Verdict & open questions
+
+Is `= me` "flawless in isolation," as asked? The *primitive* is — a strong,
+server-owned, runtime-materialized, immutable, DIRECTONLY-safe actor stamp is a
+clean self-contained concept. But the first draft was **not** flawless: the
+stress pass found three HIGH implementation-shape holes — the schema-global
+wiring reintroducing cross-request bleed (§14.3), the anonymous floor insert
+500-ing instead of 422-ing (§14.4), and the empty-input-object boot failure
+(§14.4). With those three fixed, it is. That is the harness working as intended.
+
+Open questions:
+
+**E. Should `= me` look different from `auto`/`now`?** The peer survey flags a
+real trap: `= me` sits grammatically in the `auto`/`now` family (which are weak
+and overridable) but behaves like a Hasura preset (strong, non-settable). That is
+the same "the token mis-teaches" hazard §4.1 used to reject `extends` — an author
+may assume override semantics transfer. Options: accept it with crisp load-time
+messaging, or give the preset a distinct marker. **Recommendation: keep `= me`
+(the ergonomics win of looking like a default is large) but have the checker
+state the non-settable semantics wherever it is declared.** The user's `me()`
+call-spelling vs the bare `me` (matching `auto`/`now`) is the sub-question here.
+
+**F. At most one `= me` per table, and self-side only?** A checker guard (the
+write-seam analog of §4.5) that keeps `= me` on the ownership/self column and
+flags a second one avoids nonsensical double-stamping. Lean: yes, a lint.

--- a/docs/spec/v0.md
+++ b/docs/spec/v0.md
@@ -58,19 +58,19 @@ as identifiers.
 Active in v0:
 
 ```
-table  record  fn  mut  key  unique  check  seed  on  delete  restrict
+table  auth  record  fn  mut  key  unique  check  seed  on  delete  restrict
 cascade  set  null  text  int  float  bool  timestamp  uuid
-auto  now  true  false
+auto  now  me  true  false
 ```
 
 `sql` and `unchecked` are *contextual* keywords: they form a fn body (§3)
 but remain legal identifiers everywhere else.
 
 (`set`, `null`, and `float` became keywords in July 2026, `mut` followed
-with fn v2 (RFD 0012), and `check` with the value tier (RFD 0013) —
-source-level breaks for programs that used them as identifiers. The §6
-freeze governs the contract artifact, not source compatibility; v0.x
-source may still move.)
+with fn v2 (RFD 0012), `check` with the value tier (RFD 0013), and `auth`
+and `me` with the actor seam (RFD 0014) — source-level breaks for programs
+that used them as identifiers. The §6 freeze governs the contract artifact,
+not source compatibility; v0.x source may still move.)
 
 Reserved for future versions (using one as an identifier is an error, L005):
 
@@ -88,7 +88,9 @@ does not verify it, but the runtime stays sound (RFD 0011 §3).
 ```ebnf
 file        = { table_decl | record_decl | fn_decl | seed_block } ;
 
-table_decl  = "table" ident "{" { table_item } "}" ;
+table_decl  = [ "auth" ] "table" ident "{" { table_item } "}" ;
+              (* `auth table` marks the identity anchor (RFD 0014); at most
+                 one, with a single scalar key — E045/E046 *)
 table_item  = key_decl | unique_decl | check_decl | field_decl ;
 
 record_decl = "record" ident "{" { table_item } "}" ;
@@ -125,7 +127,9 @@ set_type    = string { "|" string } ;
               (* a closed-set type (RFD 0013): the value is one of these
                  strings. The singleton/duplicate/empty-value laws are the
                  checker's, E043 *)
-default     = "auto" | "now" | literal ;
+default     = "auto" | "now" | "me" | literal ;
+              (* `me` is the current actor (RFD 0014); legal only on a
+                 reference to the `auth` table — E016 carve-out / E047 *)
 literal     = string | integer | float | "true" | "false" ;
 
 seed_block  = "seed" "{" { seed_stmt } "}" ;
@@ -228,6 +232,9 @@ fails); L-codes are lexical/parse errors.
 | E042 | `check` validator law violated: not a read fn, not `bool`, not a single clauseless `SELECT`, non-deterministic, wrong arity/param types, or attached to a closed-set/`auto`/`now` field (RFD 0013) |
 | E043 | closed-set type is degenerate: fewer than two values, a duplicated value, an empty value, or used as a key field (RFD 0013) |
 | E044 | two derived error codes collide (the constraint name is the routing channel; the underscore-join is not injective, RFD 0013) |
+| E045 | more than one `auth table` — the actor space has one identity table (RFD 0014) |
+| E046 | the `auth table`'s key is not a single scalar column (`spock_actor()` returns one value, RFD 0014) |
+| E047 | `= me` is not on a reference to the `auth` table, or no anchor is declared (RFD 0014). `= me` on a reference is the one carve-out to E016 |
 
 Notes.
 
@@ -276,17 +283,30 @@ touch this" and "unset this".
 |---|---|---|
 | `auto` | `uuid` | runtime generates a UUIDv7 at insert |
 | `now` | `timestamp` | runtime captures UTC now at insert |
+| `me` | reference to the `auth` table | runtime stamps the current actor at insert (RFD 0014) |
 | string literal | `text` | |
 | integer literal | `int` | |
 | float literal | `float` | |
 | boolean literal | `bool` | |
 
 Anything else is E009. On the floor's write path, defaults are applied
-by the runtime at insert time (§7.2); the same generators are also
-installed as engine DEFAULT clauses so escape bodies receive identical
-values (§7.1) — both paths mint from one clock and one id format, so
-every conforming runtime behaves identically and the paths cannot
-drift. Defaults apply at insert only; updates never apply them.
+by the runtime at insert time (§7.2); `auto`/`now` are *also* installed as
+engine DEFAULT clauses so escape bodies receive identical values (§7.1) —
+both paths mint from one clock and one id format, so every conforming
+runtime behaves identically and the paths cannot drift. Defaults apply at
+insert only; updates never apply them.
+
+**`me` (RFD 0014) is the exception, a *strong preset*.** It is materialized
+by the runtime on the write path like `auto`/`now`, but (a) it is **not**
+installed as a DDL DEFAULT — `spock_actor()` is DIRECTONLY (§7.1), so an
+escape that stores the actor names `spock_actor()` itself (the same value,
+one source, no drift); and (b) it is **removed from the client insert and
+update surface** (the derived GraphQL `<t>_insert_input`/`<t>_set_input` and
+the generated TS types omit it), so a client cannot forge the identity
+column. An anonymous insert of a required `= me` field is the derived
+`required` error (§7.2), not a null — the floor never stores an unauthenticated
+identity. Seed runs before any actor exists, so a seed row must name every
+required `= me` column (E022).
 
 ## 6. The compiled contract
 
@@ -339,8 +359,10 @@ so pre-fn contract JSON still loads — and `returns.scalar` on a fn
 (boolean, defaults to `false`; when set, `returns.of` names a builtin
 scalar type instead of a shape). The **vocabulary** has also grown:
 type kind `float`, default kind `float`, float seed values, and
-`on_delete: "set_null"`, and (RFD 0013) the field type kind `set`
-(`{ "kind": "set", "values": [...] }`) with the error kind `invalid`.
+`on_delete: "set_null"`, (RFD 0013) the field type kind `set`
+(`{ "kind": "set", "values": [...] }`) with the error kind `invalid`, and
+(RFD 0014) the table flag `anchor` (`true` on the one `auth table`) plus the
+default kind `actor` (`{ "kind": "actor" }`, the `= me` stamp).
 Additive means old JSON keeps loading in new
 consumers — it does not mean old consumers can read a contract that
 uses new vocabulary (a pre-float reader rejects `"kind": "float"`), and
@@ -428,13 +450,23 @@ all identifiers double-quoted:
   RESTRICT|CASCADE|SET NULL`; the runtime sets `PRAGMA foreign_keys = ON`;
 - each declared default → a `DEFAULT` clause: literals verbatim
   (strings quoted, `'` doubled), `auto` → `(spock_uuid())`, `now` →
-  `(spock_now())`.
+  `(spock_now())`. A `= me` field emits **no** `DEFAULT` clause (RFD 0014):
+  `spock_actor()` is DIRECTONLY, so the actor is materialized on the write
+  path instead (§7.2), and an escape names `spock_actor()` itself.
 
-**Engine builtins.** The runtime registers three SQL functions on the
+**Engine builtins.** The runtime registers SQL functions on the
 connection before DDL: `spock_uuid()` (UUIDv7) and `spock_now()`
 (RFC 3339 UTC) — *the same generators the write path uses* for `auto`
 and `now` — and `spock_refuse(code)`, the refusal raise channel (§7.4;
-direct-only: nothing indirect may raise). Consequences: an escape body
+direct-only: nothing indirect may raise). When a table is `auth`-marked
+(RFD 0014) a fourth is registered: **`spock_actor()`** — the current
+actor's key (§8), NULL when anonymous — registered **only** with an anchor
+present (a body that calls it without one fails at prepare, the
+identity-needs-a-consumer rule) and **DIRECTONLY** like `spock_refuse`, not
+like `spock_now`: the actor is request-scoped state, correct only inside a
+fn call, never in a DEFAULT/CHECK the actor-blind floor evaluates.
+`func::call` re-binds it to the request's actor before each fn transaction.
+Consequences: an escape body
 (§7.4) may omit defaulted columns from an INSERT and receive the
 engine's own values via the DEFAULT clauses, or call the builtins
 directly; a value minted inside the escape is indistinguishable in
@@ -459,7 +491,11 @@ sees it, inside one transaction per write.
 2. type-check each provided value (§5.1; uuid/timestamp format enforced);
    a closed-set value that is not a member → the derived `invalid` error
    (RFD 0013);
-3. apply defaults; a required field still absent → `required` error;
+3. apply defaults; a required field still absent → `required` error. A
+   `= me` field (RFD 0014) is stamped with the request actor here; an
+   anonymous insert of a required `= me` field routes to that same derived
+   `required` error (not a NULL — the floor never stores an unauthenticated
+   identity);
 4. each provided reference is checked for existence → `ref_not_found`;
 5. the engine insert runs; unique/key violations map to the derived codes.
 
@@ -565,6 +601,9 @@ data moved:
 **Execution.** One call = one transaction spanning every statement:
 `IMMEDIATE` for `mut` fns (the serializable-by-default stance, RFD
 0005), `DEFERRED` for reads — a read fn never takes the write lock.
+The request actor is bound to `spock_actor()` (§7.1) before the
+transaction opens, so any statement — read or write — may reference it
+(RFD 0014); a read fn calls it just as it may call `spock_refuse`.
 Arguments validate against the parameter types before the transaction
 opens; for fn arguments `null` means *absent* (there is no §5.1 update
 carve-out here): an absent or null optional parameter binds SQL `NULL`,
@@ -639,6 +678,17 @@ the open reads, `/graphql/v1` the GraphQL reads and writes (§8.2). Table
 names can
 therefore never collide with a protocol mount, and future surfaces (e.g.
 `/auth/v1`) claim mounts the same way.
+
+**The actor** (RFD 0014). When a table is `auth`-marked, requests may carry
+`X-Spock-Actor: <key>` — the actor's key value, verbatim and **unverified**
+in v0 (the ungoverned prototype tier; the seam a verified JWT later fills).
+It is canonicalized by the anchor's key type (an uppercased/braced uuid
+still matches) and populates `spock_actor()` (§7.1) and `= me` (§7.2) for
+that request; an absent or unparseable header is anonymous (NULL), never an
+error. Impersonation is this header against a known identity — in v0, a seed
+persona row. The header is read on `/graphql/v1` and `/rest/v1/rpc/{fn}`; the
+GraphQL actor is injected per request (never a process-global, which would
+bleed across callers). It is deliberately forgeable — v0 secures nothing.
 
 | Method & path | Meaning | Success |
 |---|---|---|
@@ -726,10 +776,13 @@ future; fns return rows or scalars (`t`, `t?`, `[t]` — no void) and
 land on the root their polarity names (§7.4 — reads on `Query`, `mut`
 on `Mutation`); records are fn return shapes
 only (not parameters, not storage); fn parameters may not reference
-composite-key tables (E036); seed may not call fns; no actor context yet
-(arrives with auth); references may not target composite-key tables
-(E010); writes are ungoverned — v0 is the open prototype tier; policy/RLS
-lands in a later version and flips the default; REST **tables** are
+composite-key tables (E036); seed may not call fns; the actor seam
+(RFD 0014) is the read/write half of identity — `spock_actor()` in fn
+bodies and `= me` on the floor — but it does **not** govern the floor:
+reads and non-`me` writes stay open, and per-row read governance, roles,
+and JWT claims arrive with `policy`/auth; references may not target
+composite-key tables (E010); writes are ungoverned — v0 is the open
+prototype tier; policy/RLS lands in a later version and flips the default; REST **tables** are
 read-only — table writes are deferred pending the filter-language
 question (writes are GraphQL-first, §8.2), while `POST /rest/v1/rpc/{fn}`
 is the deliberate REST write surface (§7.4); the former `/~dev` surface

--- a/examples/instagram/pg-rls.sql
+++ b/examples/instagram/pg-rls.sql
@@ -1,0 +1,846 @@
+-- ═══════════════════════════════════════════════════════════════════════════
+-- instagram/pg-rls.sql — the Supabase-native RLS oracle
+-- ═══════════════════════════════════════════════════════════════════════════
+--
+-- The Instagram PRD (./PRD.md) and v0 entity set (./v0.spock) implemented the
+-- way you build on Supabase: RLS *is* the authorization layer. Clients hit the
+-- tables directly (PostgREST / pg_graphql). There is NO SECURITY DEFINER
+-- function API in front of the tables — that raw-Postgres "the database is the
+-- backend, the API is functions" style is exactly what pg.sql does and what we
+-- deliberately do NOT do here.
+--
+-- The predicates are mined from pg.sql (the answer sheet) but RE-CAST:
+--   * actor          = auth.uid()               (the JWT `sub`, a profile id)
+--   * claims         = auth.jwt()               (app_metadata role, etc.)
+--   * audiences      = TO anon / TO authenticated
+--   * per-command    = separate SELECT / INSERT / UPDATE / DELETE policies
+--   * USING          governs which rows are visible to read/delete
+--   * WITH CHECK      governs which rows an insert/update may produce
+--
+-- SECURITY DEFINER helpers appear in EXACTLY two sanctioned roles:
+--   (a) anti-recursion — a policy that must read the very table it guards
+--       (post→post, comment→comment, membership→membership) would recurse; a
+--       SECURITY DEFINER function reads it once, out of band.               [P25/P37]
+--   (b) visibility hoist — the block/follow/private graph must be consulted
+--       from rows the viewer cannot themselves SELECT (you cannot see the
+--       block row that hides a post from you). A DEFINER function owned by a
+--       BYPASSRLS role (postgres, on Supabase) sees the whole graph so the
+--       predicate is correct. Clients never gain that reach.
+--
+-- The graph/visibility helpers live in a NON-EXPOSED schema `private` (see §3):
+-- they take arbitrary principals as arguments and run BYPASSRLS, so leaving them
+-- in `public` — a PostgREST-exposed schema — would publish them as RPC
+-- endpoints (`/rest/v1/rpc/is_blocked_between?a=..&b=..`) and leak exactly the
+-- block/follow secrets the policies protect. `private` is not in PostgREST's
+-- exposed-schema list, so RLS can still call the functions cross-schema while no
+-- client can reach them directly.
+--
+-- Assumes a Supabase database: schema `auth` with auth.users, the functions
+-- auth.uid()/auth.jwt(), and the roles `anon` and `authenticated`. A profile
+-- row is keyed 1:1 to auth.users — so auth.uid() *is* the current profile id,
+-- and the account/profile split of pg.sql collapses into Supabase's auth.users.
+--
+-- Run:  psql / Supabase SQL editor. Idempotent-ish within a fresh schema.
+-- ═══════════════════════════════════════════════════════════════════════════
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- §1  Tables — social core (minimal columns; only what authorization reads)
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- profile.id = auth.users.id : the JWT subject is the profile identity.
+create table public.profile (
+  id         uuid primary key references auth.users (id) on delete cascade,
+  username   text not null unique check (username ~ '^[a-z0-9._]{1,30}$'),
+  full_name  text,
+  bio        text,
+  private    boolean not null default false,   -- public vs private account
+  created_at timestamptz not null default now()
+);
+
+-- reference data: imported from a places provider, never minted by clients.
+create table public.location (
+  id       uuid primary key default gen_random_uuid(),
+  name     text not null,
+  place_id text not null unique
+);
+
+create table public.post (
+  id          uuid primary key default gen_random_uuid(),
+  author_id   uuid not null references public.profile (id) on delete cascade,
+  caption     text,
+  location_id uuid references public.location (id),
+  archived_at timestamptz,                       -- archived ⇒ author-only
+  created_at  timestamptz not null default now()
+);
+create index on public.post (author_id, created_at desc);
+
+create table public.media (
+  id         uuid primary key default gen_random_uuid(),
+  post_id    uuid not null references public.post (id) on delete cascade,
+  position   int  not null check (position >= 0),
+  kind       text not null check (kind in ('image', 'video')),
+  created_at timestamptz not null default now(),
+  unique (post_id, position)
+);
+
+create table public.follow (
+  follower_id uuid not null references public.profile (id) on delete cascade,
+  followee_id uuid not null references public.profile (id) on delete cascade,
+  created_at  timestamptz not null default now(),
+  primary key (follower_id, followee_id),
+  check (follower_id <> followee_id)            -- no self-follow (DDL, not RLS)
+);
+create index on public.follow (followee_id, follower_id);
+
+create table public.follow_request (
+  requester_id uuid not null references public.profile (id) on delete cascade,
+  target_id    uuid not null references public.profile (id) on delete cascade,
+  status       text not null default 'pending'
+               check (status in ('pending', 'approved', 'denied')),
+  created_at   timestamptz not null default now(),
+  responded_at timestamptz,
+  primary key (requester_id, target_id),
+  check (requester_id <> target_id)
+);
+
+create table public.block (
+  blocker_id uuid not null references public.profile (id) on delete cascade,
+  blocked_id uuid not null references public.profile (id) on delete cascade,
+  created_at timestamptz not null default now(),
+  primary key (blocker_id, blocked_id),
+  check (blocker_id <> blocked_id)
+);
+create index on public.block (blocked_id, blocker_id);
+
+create table public.restriction (
+  restrictor_id uuid not null references public.profile (id) on delete cascade,
+  restricted_id uuid not null references public.profile (id) on delete cascade,
+  created_at    timestamptz not null default now(),
+  primary key (restrictor_id, restricted_id),
+  check (restrictor_id <> restricted_id)
+);
+
+create table public.post_like (
+  profile_id uuid not null references public.profile (id) on delete cascade,
+  post_id    uuid not null references public.post (id)    on delete cascade,
+  created_at timestamptz not null default now(),
+  primary key (profile_id, post_id)             -- like a post at most once
+);
+create index on public.post_like (post_id);
+
+create table public.comment (
+  id         uuid primary key default gen_random_uuid(),
+  post_id    uuid not null references public.post (id)     on delete cascade,
+  author_id  uuid not null references public.profile (id)  on delete cascade,
+  parent_id  uuid references public.comment (id) on delete set null,
+  body       text not null check (length(btrim(body)) between 1 and 2200),
+  status     text not null default 'visible'
+             check (status in ('visible', 'held')),   -- held ⇒ author+owner only
+  created_at timestamptz not null default now()
+);
+create index on public.comment (post_id, created_at);
+
+create table public.save (
+  profile_id uuid not null references public.profile (id) on delete cascade,
+  post_id    uuid not null references public.post (id)    on delete cascade,
+  created_at timestamptz not null default now(),
+  primary key (profile_id, post_id)             -- private library, by shape
+);
+
+create table public.collection (
+  id         uuid primary key default gen_random_uuid(),
+  owner_id   uuid not null references public.profile (id) on delete cascade,
+  name       text not null check (length(name) between 1 and 50),
+  created_at timestamptz not null default now(),
+  unique (owner_id, name)
+);
+
+create table public.collection_item (
+  collection_id uuid not null references public.collection (id) on delete cascade,
+  post_id       uuid not null references public.post (id)       on delete cascade,
+  added_at      timestamptz not null default now(),
+  primary key (collection_id, post_id)
+);
+
+create table public.mention (
+  id            uuid primary key default gen_random_uuid(),
+  mentioned_id  uuid not null references public.profile (id) on delete cascade,
+  post_id       uuid references public.post (id)    on delete cascade,
+  comment_id    uuid references public.comment (id) on delete cascade,
+  display       text not null,
+  created_at    timestamptz not null default now(),
+  check (num_nonnulls(post_id, comment_id) = 1)     -- exactly one source
+);
+
+create table public.media_tag (
+  id         uuid primary key default gen_random_uuid(),
+  media_id   uuid not null references public.media (id)   on delete cascade,
+  tagged_id  uuid not null references public.profile (id) on delete cascade,
+  x          real not null check (x between 0 and 1),
+  y          real not null check (y between 0 and 1),
+  created_at timestamptz not null default now(),
+  unique (media_id, tagged_id)
+);
+
+create table public.hashtag (
+  tag        text primary key check (tag ~ '^[a-z0-9_]{1,64}$'),
+  created_at timestamptz not null default now()
+);
+
+create table public.post_hashtag (
+  post_id uuid not null references public.post (id) on delete cascade,
+  tag     text not null references public.hashtag (tag),
+  primary key (post_id, tag)
+);
+
+-- report subjects use ON DELETE CASCADE (mirroring `mention`): a report is about
+-- exactly one subject (the num_nonnulls check), so if the subject is deleted the
+-- report goes with it. ON DELETE SET NULL would blank the only non-null column
+-- and violate `num_nonnulls(...) = 1`, aborting the subject's own delete.
+create table public.report (
+  id          uuid primary key default gen_random_uuid(),
+  reporter_id uuid not null references public.profile (id) on delete cascade,
+  post_id     uuid references public.post (id)    on delete cascade,
+  comment_id  uuid references public.comment (id) on delete cascade,
+  profile_id  uuid references public.profile (id) on delete cascade,
+  reason      text not null check (length(btrim(reason)) > 0),
+  status      text not null default 'open'
+              check (status in ('open', 'reviewed', 'actioned')),
+  created_at  timestamptz not null default now(),
+  check (num_nonnulls(post_id, comment_id, profile_id) = 1)
+);
+
+create table public.notification (
+  id           bigint generated always as identity primary key,
+  recipient_id uuid not null references public.profile (id) on delete cascade,
+  actor_id     uuid references public.profile (id) on delete cascade,
+  kind         text not null check (kind in
+               ('follow','follow_request','like','comment','mention','tag')),
+  post_id      uuid references public.post (id)    on delete cascade,
+  comment_id   uuid references public.comment (id) on delete cascade,
+  created_at   timestamptz not null default now(),
+  read_at      timestamptz
+);
+create index on public.notification (recipient_id, id desc);
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- §2  Tables — enterprise RBAC addendum (the role-gated family)
+-- ─────────────────────────────────────────────────────────────────────────────
+
+create table public.organization (
+  id         uuid primary key default gen_random_uuid(),
+  name       text not null,
+  owner_id   uuid not null references public.profile (id) on delete restrict,
+  created_at timestamptz not null default now()
+);
+
+-- membership.role is the RBAC axis. A naive "members can see co-members" policy
+-- that reads membership would recurse; §3's is_org_member() / org_role() break
+-- the cycle with SECURITY DEFINER.
+create table public.membership (
+  org_id     uuid not null references public.organization (id) on delete cascade,
+  member_id  uuid not null references public.profile (id)      on delete cascade,
+  role       text not null default 'member'
+             check (role in ('owner', 'admin', 'member')),
+  created_at timestamptz not null default now(),
+  primary key (org_id, member_id)
+);
+
+-- the one org-owned resource: any member reads, only owner/admin writes.
+create table public.org_setting (
+  org_id     uuid not null references public.organization (id) on delete cascade,
+  key        text not null,
+  value      text not null,
+  updated_at timestamptz not null default now(),
+  primary key (org_id, key)
+);
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- §3  Authorization helpers — SECURITY DEFINER STABLE, in schema `private`
+--     Owned by postgres (a BYPASSRLS role on Supabase), so they read the whole
+--     block/follow/private graph regardless of the caller's RLS — and are not
+--     re-entered by the policies that call them. search_path is pinned to
+--     defeat search-path hijack. auth.uid() still resolves inside a DEFINER
+--     function (it reads the request JWT GUC, not the current role).
+--
+--     WHY `private`, not `public`: PostgREST exposes `public`, so any function
+--     there becomes a callable RPC. is_blocked_between(a,b)/is_follower(a,b)
+--     take ARBITRARY principals and run BYPASSRLS — as public RPCs they would
+--     let anyone (even anon) probe the block/follow graph, defeating block
+--     secrecy. `private` is outside PostgREST's exposed-schema list, so the
+--     functions stay callable from RLS (cross-schema) but unreachable as RPC.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+create schema if not exists private;
+
+-- blocking severs visibility BOTH ways; anon (a IS NULL) is never blocked.
+create or replace function private.is_blocked_between(a uuid, b uuid)
+returns boolean language sql stable security definer set search_path = public, pg_temp as $$
+  select a is not null and b is not null and exists (
+    select 1 from public.block
+     where (blocker_id = a and blocked_id = b)
+        or (blocker_id = b and blocked_id = a));
+$$;
+
+-- "a follows b" — the follow row IS the approval (private accounts only get one
+-- through the approve trigger in §4).
+create or replace function private.is_follower(a uuid, b uuid)
+returns boolean language sql stable security definer set search_path = public, pg_temp as $$
+  select a is not null and exists (
+    select 1 from public.follow where follower_id = a and followee_id = b);
+$$;
+
+create or replace function private.profile_is_public(p uuid)
+returns boolean language sql stable security definer set search_path = public, pg_temp as $$
+  select exists (select 1 from public.profile where id = p and not private);
+$$;
+
+-- profile visibility: public, or self, or approved follower — never across a
+-- block. Anon sees public profiles only. (SECURITY DEFINER: also stops the
+-- profile SELECT policy that calls it from recursing on profile.)
+create or replace function private.can_view_profile(target uuid)
+returns boolean language sql stable security definer set search_path = public, pg_temp as $$
+  select exists (
+    select 1 from public.profile p
+     where p.id = target
+       and not private.is_blocked_between(auth.uid(), target)
+       and ( not p.private
+             or p.id = auth.uid()
+             or private.is_follower(auth.uid(), p.id) ));
+$$;
+
+-- THE post-visibility predicate — the one gate behind feed, grid, detail,
+-- hashtag/location pages, saved & tagged surfaces, direct links. Author sees
+-- their own posts (incl. archived); everyone else needs a visible, non-archived
+-- post whose author's content they may see. SECURITY DEFINER ⇒ no post→post
+-- recursion.
+create or replace function private.can_view_post(p_post uuid)
+returns boolean language sql stable security definer set search_path = public, pg_temp as $$
+  select exists (
+    select 1 from public.post p
+     where p.id = p_post
+       and ( p.author_id = auth.uid()
+             or ( p.archived_at is null
+                  and private.can_view_profile(p.author_id) ) ));
+$$;
+
+-- comment visibility: on a viewable post, and either 'visible', or 'held' but
+-- the viewer is its author or the post owner (the restriction rule).
+create or replace function private.can_view_comment(p_comment uuid)
+returns boolean language sql stable security definer set search_path = public, pg_temp as $$
+  select exists (
+    select 1 from public.comment c join public.post p on p.id = c.post_id
+     where c.id = p_comment
+       and private.can_view_post(c.post_id)
+       and ( c.status = 'visible'
+             or c.author_id = auth.uid()
+             or p.author_id = auth.uid() ));
+$$;
+
+create or replace function private.is_post_owner(p_post uuid)
+returns boolean language sql stable security definer set search_path = public, pg_temp as $$
+  select exists (select 1 from public.post where id = p_post and author_id = auth.uid());
+$$;
+
+-- RBAC, recursion-safe: read membership out of band so membership's own
+-- policies can consult it.
+create or replace function private.is_org_member(p_org uuid)
+returns boolean language sql stable security definer set search_path = public, pg_temp as $$
+  select exists (select 1 from public.membership
+                  where org_id = p_org and member_id = auth.uid());
+$$;
+
+create or replace function private.org_role(p_org uuid)
+returns text language sql stable security definer set search_path = public, pg_temp as $$
+  select role from public.membership
+   where org_id = p_org and member_id = auth.uid();
+$$;
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- §4  Correctness triggers — the state transitions RLS cannot express
+--     (RLS decides who may act; these carry the consequences of the act, and
+--     pin the columns RLS's WITH CHECK cannot — RLS sees only the NEW row, so
+--     "column X may not change" and "this transition is the only legal one" are
+--     BEFORE-triggers, not policies.)
+--     All SECURITY DEFINER so they may write rows the actor's own policies
+--     forbid (e.g. a private-account follow the follow INSERT policy blocks).
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- Approving a follow request materializes the follow edge (the private path).
+-- The parties are IMMUTABLE: without this guard a target could rewrite
+-- requester_id to a victim and approve, forging a follow the victim never asked
+-- for (RLS WITH CHECK cannot see OLD, so it cannot pin the identity columns).
+create or replace function public.tg_follow_request_approved()
+returns trigger language plpgsql security definer set search_path = public, pg_temp as $$
+begin
+  if new.requester_id is distinct from old.requester_id
+     or new.target_id is distinct from old.target_id then
+    raise exception 'follow_request parties are immutable';
+  end if;
+  if new.status = 'approved' and old.status is distinct from 'approved' then
+    insert into public.follow (follower_id, followee_id)
+    values (new.requester_id, new.target_id)
+    on conflict do nothing;
+    new.responded_at := now();
+  elsif new.status = 'denied' and old.status is distinct from 'denied' then
+    new.responded_at := now();
+  end if;
+  return new;
+end $$;
+create trigger trg_follow_request_approved
+  before update on public.follow_request
+  for each row execute function public.tg_follow_request_approved();
+
+-- A restricted user's comment lands 'held' (visible to author + post owner
+-- only). Column state, not authorization — so it belongs in a trigger.
+create or replace function public.tg_comment_hold_if_restricted()
+returns trigger language plpgsql security definer set search_path = public, pg_temp as $$
+begin
+  if exists (
+    select 1 from public.restriction r
+      join public.post p on p.id = new.post_id
+     where r.restrictor_id = p.author_id and r.restricted_id = new.author_id)
+  then
+    new.status := 'held';
+  end if;
+  return new;
+end $$;
+create trigger trg_comment_hold
+  before insert on public.comment
+  for each row execute function public.tg_comment_hold_if_restricted();
+
+-- comment_update's policy lets the post owner touch a comment, but the ONLY
+-- legal edit is approving a held comment (held → visible). Everything else —
+-- rewriting the body, reassigning author_id, re-holding a visible comment — is
+-- content forgery. RLS can't scope columns or reference OLD, so pin it here.
+create or replace function public.tg_comment_owner_edit_guard()
+returns trigger language plpgsql security definer set search_path = public, pg_temp as $$
+begin
+  if new.post_id    is distinct from old.post_id
+     or new.author_id  is distinct from old.author_id
+     or new.parent_id  is distinct from old.parent_id
+     or new.body       is distinct from old.body
+     or new.created_at is distinct from old.created_at then
+    raise exception 'only a comment''s status may change (held->visible)';
+  end if;
+  if new.status is distinct from old.status
+     and not (old.status = 'held' and new.status = 'visible') then
+    raise exception 'comment status may only move held->visible';
+  end if;
+  return new;
+end $$;
+create trigger trg_comment_owner_edit_guard
+  before update on public.comment
+  for each row execute function public.tg_comment_owner_edit_guard();
+
+-- notification_update's policy is scoped to the recipient, but the only field a
+-- recipient may change is read_at (mark read/unread). Pin the rest so a client
+-- can't rewrite the kind/actor/subject of its own notifications.
+create or replace function public.tg_notification_readonly()
+returns trigger language plpgsql security definer set search_path = public, pg_temp as $$
+begin
+  if new.recipient_id is distinct from old.recipient_id
+     or new.actor_id   is distinct from old.actor_id
+     or new.kind       is distinct from old.kind
+     or new.post_id    is distinct from old.post_id
+     or new.comment_id is distinct from old.comment_id
+     or new.created_at is distinct from old.created_at then
+    raise exception 'only read_at may change on a notification';
+  end if;
+  return new;
+end $$;
+create trigger trg_notification_readonly
+  before update on public.notification
+  for each row execute function public.tg_notification_readonly();
+
+-- Creating an org makes the creator its owner-member (bootstraps RBAC; the
+-- membership INSERT policy can't, since the creator has no role row yet).
+create or replace function public.tg_org_owner_membership()
+returns trigger language plpgsql security definer set search_path = public, pg_temp as $$
+begin
+  insert into public.membership (org_id, member_id, role)
+  values (new.id, new.owner_id, 'owner')
+  on conflict do nothing;
+  return new;
+end $$;
+create trigger trg_org_owner
+  after insert on public.organization
+  for each row execute function public.tg_org_owner_membership();
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- §5  Enable RLS on every app table. FORCE on the privacy-critical ones.
+--     RLS enabled ⇒ default-deny: with no policy, a command sees/writes zero
+--     rows. anon simply gets no write policy anywhere, so it can write nothing.
+--
+--     FORCE note: the table OWNER bypasses RLS unless FORCEd. On Supabase the
+--     owner is postgres (BYPASSRLS — so even FORCE won't subject our DEFINER
+--     helpers to RLS, which is what we want). FORCE matters the day the app
+--     connects as a plain owner role, or an owned-but-not-BYPASSRLS role runs
+--     ad-hoc DML: these tables must still enforce their policies. Belt and
+--     suspenders on the rows that would hurt most if leaked.
+--
+--     `membership` is deliberately NOT FORCEd. Its membership_read policy calls
+--     is_org_member(), a DEFINER helper that itself reads `membership`. Under a
+--     non-BYPASSRLS owner FORCE would subject that inner read to membership_read
+--     again — reintroducing exactly the recursion the DEFINER exists to break.
+--     The anti-recursion guarantee for any table whose own DEFINER helper reads
+--     it depends on the helper's owner bypassing that table's RLS; FORCE would
+--     void it. (org_setting stays FORCEd safely: its helpers read `membership`,
+--     never `org_setting`, so no self-recursion.)
+-- ─────────────────────────────────────────────────────────────────────────────
+
+alter table public.profile         enable row level security;
+alter table public.location        enable row level security;
+alter table public.post            enable row level security;
+alter table public.media           enable row level security;
+alter table public.follow          enable row level security;
+alter table public.follow_request  enable row level security;
+alter table public.block           enable row level security;
+alter table public.restriction     enable row level security;
+alter table public.post_like       enable row level security;
+alter table public.comment         enable row level security;
+alter table public.save            enable row level security;
+alter table public.collection      enable row level security;
+alter table public.collection_item enable row level security;
+alter table public.mention         enable row level security;
+alter table public.media_tag       enable row level security;
+alter table public.hashtag         enable row level security;
+alter table public.post_hashtag    enable row level security;
+alter table public.report          enable row level security;
+alter table public.notification    enable row level security;
+alter table public.organization    enable row level security;
+alter table public.membership      enable row level security;
+alter table public.org_setting     enable row level security;
+
+alter table public.save            force row level security;
+alter table public.collection      force row level security;
+alter table public.collection_item force row level security;
+alter table public.follow_request  force row level security;
+alter table public.block           force row level security;
+alter table public.restriction     force row level security;
+alter table public.report          force row level security;
+alter table public.notification    force row level security;
+alter table public.org_setting     force row level security;
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- §6  Policies — social core
+--     Convention: (select auth.uid()) so the planner hoists it to an initplan
+--     (evaluated once, not per row). anon has a NULL uid, so every self / owner
+--     / follower test collapses to false — anon reads only what a policy hands
+--     to `anon` explicitly, and writes nothing.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- profile ─ public shells to anyone; private details to self + approved
+-- followers; never across a block.
+create policy profile_read on public.profile
+  for select to anon, authenticated
+  using ( private.can_view_profile(id) );
+create policy profile_insert on public.profile
+  for insert to authenticated
+  with check ( id = (select auth.uid()) );          -- may only mint your own row
+create policy profile_update on public.profile
+  for update to authenticated
+  using ( id = (select auth.uid()) )
+  with check ( id = (select auth.uid()) );
+
+-- location ─ reference data: world-readable, client-unwritable (no write policy).
+create policy location_read on public.location
+  for select to anon, authenticated
+  using ( true );
+
+-- post ─ author public / self / approved follower, not blocked, archived⇒author.
+create policy post_read on public.post
+  for select to anon, authenticated
+  using ( private.can_view_post(id) );
+create policy post_insert on public.post
+  for insert to authenticated
+  with check ( author_id = (select auth.uid()) );
+create policy post_update on public.post                -- edit + archive/unarchive
+  for update to authenticated
+  using ( author_id = (select auth.uid()) )
+  with check ( author_id = (select auth.uid()) );
+create policy post_delete on public.post
+  for delete to authenticated
+  using ( author_id = (select auth.uid()) );
+
+-- media ─ rides its post's visibility; only the post's author may attach it.
+create policy media_read on public.media
+  for select to anon, authenticated
+  using ( private.can_view_post(post_id) );
+create policy media_insert on public.media
+  for insert to authenticated
+  with check ( private.is_post_owner(post_id) );
+
+-- follow ─ both parties see the edge; you may direct-follow only PUBLIC, unblocked
+-- accounts (private ⇒ follow_request); either party may drop it.
+create policy follow_read on public.follow
+  for select to authenticated
+  using ( follower_id = (select auth.uid()) or followee_id = (select auth.uid()) );
+create policy follow_insert on public.follow
+  for insert to authenticated
+  with check ( follower_id = (select auth.uid())
+               and private.profile_is_public(followee_id)
+               and not private.is_blocked_between((select auth.uid()), followee_id) );
+create policy follow_delete on public.follow
+  for delete to authenticated
+  using ( follower_id = (select auth.uid()) or followee_id = (select auth.uid()) );
+
+-- follow_request ─ both parties see it; you request only a PRIVATE, unblocked
+-- account; only the TARGET approves/denies (status flip → §4 trigger makes the
+-- follow, and pins the immutable parties).
+create policy follow_request_read on public.follow_request
+  for select to authenticated
+  using ( requester_id = (select auth.uid()) or target_id = (select auth.uid()) );
+create policy follow_request_insert on public.follow_request
+  for insert to authenticated
+  with check ( requester_id = (select auth.uid())
+               and not private.profile_is_public(target_id)
+               and not private.is_blocked_between((select auth.uid()), target_id) );
+create policy follow_request_update on public.follow_request
+  for update to authenticated
+  using ( target_id = (select auth.uid()) )
+  with check ( target_id = (select auth.uid()) );
+
+-- block ─ visible only to the blocker (the blocked must not learn of it);
+-- create/remove your own.
+create policy block_read on public.block
+  for select to authenticated
+  using ( blocker_id = (select auth.uid()) );
+create policy block_insert on public.block
+  for insert to authenticated
+  with check ( blocker_id = (select auth.uid()) );
+create policy block_delete on public.block
+  for delete to authenticated
+  using ( blocker_id = (select auth.uid()) );
+
+-- restriction ─ quieter than a block: visible only to the restrictor; its
+-- consequence (held comments) is applied by the §4 trigger.
+create policy restriction_read on public.restriction
+  for select to authenticated
+  using ( restrictor_id = (select auth.uid()) );
+create policy restriction_insert on public.restriction
+  for insert to authenticated
+  with check ( restrictor_id = (select auth.uid()) );
+create policy restriction_delete on public.restriction
+  for delete to authenticated
+  using ( restrictor_id = (select auth.uid()) );
+
+-- like ─ readable wherever the post is; you may like (as yourself) only a post
+-- you can see; unlike your own.
+create policy like_read on public.post_like
+  for select to anon, authenticated
+  using ( private.can_view_post(post_id) );
+create policy like_insert on public.post_like
+  for insert to authenticated
+  with check ( profile_id = (select auth.uid())
+               and private.can_view_post(post_id) );
+create policy like_delete on public.post_like
+  for delete to authenticated
+  using ( profile_id = (select auth.uid()) );
+
+-- comment ─ visible ones ride the post; held ones only to author + post owner;
+-- comment on a post you can see; post owner may approve (update) a held one
+-- (the §4 guard pins the transition to held→visible); author OR post owner may
+-- delete.
+create policy comment_read on public.comment
+  for select to anon, authenticated
+  using ( private.can_view_comment(id) );
+create policy comment_insert on public.comment
+  for insert to authenticated
+  with check ( author_id = (select auth.uid())
+               and private.can_view_post(post_id) );
+create policy comment_update on public.comment                -- owner approves held
+  for update to authenticated
+  using ( private.is_post_owner(post_id) )
+  with check ( private.is_post_owner(post_id) );
+create policy comment_delete on public.comment
+  for delete to authenticated
+  using ( author_id = (select auth.uid()) or private.is_post_owner(post_id) );
+
+-- save ─ a private library: only the saver reads it; save only visible posts;
+-- unsave your own.
+create policy save_read on public.save
+  for select to authenticated
+  using ( profile_id = (select auth.uid()) );
+create policy save_insert on public.save
+  for insert to authenticated
+  with check ( profile_id = (select auth.uid())
+               and private.can_view_post(post_id) );
+create policy save_delete on public.save
+  for delete to authenticated
+  using ( profile_id = (select auth.uid()) );
+
+-- collection ─ private to the owner.
+create policy collection_read on public.collection
+  for select to authenticated
+  using ( owner_id = (select auth.uid()) );
+create policy collection_insert on public.collection
+  for insert to authenticated
+  with check ( owner_id = (select auth.uid()) );
+create policy collection_delete on public.collection
+  for delete to authenticated
+  using ( owner_id = (select auth.uid()) );
+
+-- collection_item ─ inside your own collection; an item may be filed only if the
+-- post is one YOU have saved (the cross-table rule, as a WITH CHECK).
+create policy collection_item_read on public.collection_item
+  for select to authenticated
+  using ( exists (select 1 from public.collection c
+                   where c.id = collection_id and c.owner_id = (select auth.uid())) );
+create policy collection_item_insert on public.collection_item
+  for insert to authenticated
+  with check ( exists (select 1 from public.collection c
+                        where c.id = collection_id and c.owner_id = (select auth.uid()))
+               and exists (select 1 from public.save s
+                            where s.post_id = collection_item.post_id
+                              and s.profile_id = (select auth.uid())) );
+create policy collection_item_delete on public.collection_item
+  for delete to authenticated
+  using ( exists (select 1 from public.collection c
+                   where c.id = collection_id and c.owner_id = (select auth.uid())) );
+
+-- mention ─ rides the visibility of whichever source (post or comment) carries it.
+-- Derived server-side from caption/comment text (no client INSERT policy — like
+-- notifications, mentions are minted by activity triggers / the service role).
+create policy mention_read on public.mention
+  for select to anon, authenticated
+  using ( (post_id    is not null and private.can_view_post(post_id))
+       or (comment_id is not null and private.can_view_comment(comment_id)) );
+
+-- media_tag ─ visible to anyone who can see the post (via its media); the post's
+-- author attaches tags; a tagged user may remove themselves.
+create policy media_tag_read on public.media_tag
+  for select to anon, authenticated
+  using ( exists (select 1 from public.media m where m.id = media_id) )   -- media RLS = post visibility
+;
+create policy media_tag_insert on public.media_tag
+  for insert to authenticated
+  with check ( exists (select 1 from public.media m
+                        join public.post p on p.id = m.post_id
+                       where m.id = media_id and p.author_id = (select auth.uid())) );
+create policy media_tag_delete on public.media_tag
+  for delete to authenticated
+  using ( tagged_id = (select auth.uid()) );
+
+-- hashtag / post_hashtag ─ the discovery join. hashtag rows are public labels;
+-- a post_hashtag link is visible only if its post is (so private posts never
+-- surface on a hashtag page, no matter who asks). Both are derived server-side
+-- from caption text — no client INSERT policy, so clients cannot mint labels or
+-- links (matching the mention / notification pattern).
+create policy hashtag_read on public.hashtag
+  for select to anon, authenticated
+  using ( true );
+create policy post_hashtag_read on public.post_hashtag
+  for select to anon, authenticated
+  using ( private.can_view_post(post_id) );
+
+-- report ─ reporter-only reads; plus a claims-gated moderator override.
+create policy report_read_own on public.report
+  for select to authenticated
+  using ( reporter_id = (select auth.uid()) );
+-- jwt-claims: platform staff carrying app_metadata.role = 'moderator' read all.
+create policy report_read_moderator on public.report
+  for select to authenticated
+  using ( (auth.jwt() -> 'app_metadata' ->> 'role') = 'moderator' );
+create policy report_insert on public.report
+  for insert to authenticated
+  with check ( reporter_id = (select auth.uid()) );
+
+-- notification ─ recipient-only; recipient marks them read (update, pinned to
+-- read_at by the §4 guard). No client INSERT policy: notifications are written
+-- by SECURITY DEFINER activity triggers / the service role, never by clients.
+create policy notification_read on public.notification
+  for select to authenticated
+  using ( recipient_id = (select auth.uid()) );
+create policy notification_update on public.notification
+  for update to authenticated
+  using ( recipient_id = (select auth.uid()) )
+  with check ( recipient_id = (select auth.uid()) );
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- §7  Policies — enterprise RBAC addendum  (patterns: rbac-role, jwt-claims)
+--     The role gate checks WHO acts AND WHAT they may touch: an admin may not
+--     act on, assign, or become the `owner` role — only an owner can. Without
+--     the target-role guard an admin could demote/remove the owner or mint a
+--     second owner (the actor-only check is a classic RBAC escalation hole).
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- organization ─ members see their orgs; the creator opens one as its owner
+-- (the §4 trigger then writes their owner-membership).
+create policy org_read on public.organization
+  for select to authenticated
+  using ( private.is_org_member(id) );
+create policy org_insert on public.organization
+  for insert to authenticated
+  with check ( owner_id = (select auth.uid()) );
+
+-- membership ─ co-members see the roster (recursion-safe via is_org_member);
+-- owner/admin add or re-role members, but only an OWNER may touch an owner row
+-- or assign the owner role; a member may always remove themselves (leave).
+create policy membership_read on public.membership
+  for select to authenticated
+  using ( private.is_org_member(org_id) );
+create policy membership_insert on public.membership
+  for insert to authenticated
+  with check ( private.org_role(org_id) = 'owner'
+               or (private.org_role(org_id) = 'admin' and role <> 'owner') );
+create policy membership_update on public.membership
+  for update to authenticated
+  using ( private.org_role(org_id) = 'owner'                       -- target row (OLD)
+          or (private.org_role(org_id) = 'admin' and role <> 'owner') )
+  with check ( private.org_role(org_id) = 'owner'                  -- resulting row (NEW)
+               or (private.org_role(org_id) = 'admin' and role <> 'owner') );
+create policy membership_delete on public.membership
+  for delete to authenticated
+  using ( private.org_role(org_id) = 'owner'
+          or (private.org_role(org_id) = 'admin' and role <> 'owner')  -- admin: non-owner rows only
+          or member_id = (select auth.uid()) );                        -- anyone may leave
+
+-- org_setting ─ the role-gated resource: ANY member reads; only owner/admin
+-- writes. Non-members match nothing → they see and touch nothing.
+create policy org_setting_read on public.org_setting
+  for select to authenticated
+  using ( private.is_org_member(org_id) );
+create policy org_setting_insert on public.org_setting
+  for insert to authenticated
+  with check ( private.org_role(org_id) in ('owner', 'admin') );
+create policy org_setting_update on public.org_setting
+  for update to authenticated
+  using ( private.org_role(org_id) in ('owner', 'admin') )
+  with check ( private.org_role(org_id) in ('owner', 'admin') );
+create policy org_setting_delete on public.org_setting
+  for delete to authenticated
+  using ( private.org_role(org_id) in ('owner', 'admin') );
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- §8  Grants — PostgREST needs the table privilege too; RLS then filters rows.
+--     anon: SELECT only (may read public content, may write NOTHING).
+--     authenticated: full DML, narrowed by the policies above.
+--
+--     The §3 helpers live in `private`: RLS evaluation requires the querying
+--     role to hold EXECUTE, so we grant usage+execute on `private` — but because
+--     `private` is not a PostgREST-exposed schema, that grant does NOT publish
+--     them as RPC. The §4 functions return `trigger` (never RPC-exposable) and
+--     fire regardless of caller EXECUTE, so they need no grant.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+grant usage on schema public to anon, authenticated;
+grant usage on schema private to anon, authenticated;
+grant select on all tables in schema public to anon;
+grant select, insert, update, delete on all tables in schema public to authenticated;
+grant execute on all functions in schema private to anon, authenticated;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Deliberately elsewhere (not authorization, so not here): denormalized counters
+-- and their triggers, notification fan-out, media-processing state machine,
+-- moderation review workflow, feed fan-out at scale, rate limiting. This file
+-- owns exactly one thing — who may see and do what — and says it in policies.
+-- ═══════════════════════════════════════════════════════════════════════════

--- a/examples/instagram/v0.spock
+++ b/examples/instagram/v0.spock
@@ -67,7 +67,10 @@ fn distinct_pair(a: uuid, b: uuid) -> bool {
 // people and places
 // ---------------------------------------------------------------------------
 
-table user {
+// the identity anchor (RFD 0014): `user.id` is the actor. `spock_actor()`
+// returns it and `= me` stamps it; a dev `X-Spock-Actor` header (or a seed
+// persona) selects who is calling — the seam a verified JWT later fills.
+auth table user {
   key id: uuid = auto
   username: text check valid_username unique
   full_name: text?
@@ -88,7 +91,10 @@ table location {
 
 table post {
   key id: uuid = auto
-  author: user
+  // `= me` (RFD 0014): the floor stamps the author from the session and a
+  // client cannot forge it — `author` leaves post_insert_input. G12's
+  // authorship-forgery half, closed on the floor.
+  author: user = me
   caption: text?
   location: location?
   archived_at: timestamp?      // archive keeps likes/comments; delete cascades them
@@ -652,19 +658,22 @@ mut fn remove_media_tag(tag: media_tag, actor: user) -> media_tag? {
   """)
 }
 
-mut fn archive_post(post: post, author: user) -> post? {
+// the author archives their own post — the actor is the seam now, not a
+// client-asserted param (RFD 0014, G12 sound): a non-author matches no row
+// (arity miss = not_found), anonymous (NULL) likewise.
+mut fn archive_post(post: post) -> post? {
   unchecked sql("""
     UPDATE post
     SET archived_at = coalesce(archived_at, spock_now())
-    WHERE id = :post AND author = :author
+    WHERE id = :post AND author = spock_actor()
     RETURNING *
   """)
 }
 
-mut fn unarchive_post(post: post, author: user) -> post? {
+mut fn unarchive_post(post: post) -> post? {
   unchecked sql("""
     UPDATE post SET archived_at = NULL
-    WHERE id = :post AND author = :author
+    WHERE id = :post AND author = spock_actor()
     RETURNING *
   """)
 }
@@ -673,10 +682,10 @@ mut fn unarchive_post(post: post, author: user) -> post? {
 // likes, comments, saves, collection entries, hashtag links, mentions,
 // tags, notifications — while reports survive with nulled links (the
 // set-null half of G7; soft delete remains the full audit answer)
-mut fn delete_post(post: post, author: user) -> post? {
+mut fn delete_post(post: post) -> post? {
   unchecked sql("""
     DELETE FROM post
-    WHERE id = :post AND author = :author
+    WHERE id = :post AND author = spock_actor()
     RETURNING *
   """)
 }


### PR DESCRIPTION
## The actor seam — identity's minimal core (RFD 0014)

Adds the read/write halves of identity to Spock, plus dev-time impersonation, so a prototype can be *played as different users* and `fn` guards become sound instead of trusting a client-asserted parameter (the "G12" pain that ran through the instagram dogfood).

Design record: [`docs/rfd/0014-actor-seam.md`](docs/rfd/0014-actor-seam.md). Produced by a judged design panel and hardened by two harnesses — an adversarial review and a Supabase-native **RLS cross-check** oracle ([`examples/instagram/pg-rls.sql`](examples/instagram/pg-rls.sql), 59 policies) — whose findings are folded into the RFD.

### What ships

Three runtime-minted defaults now map to three builtins: **`auto`↔`spock_uuid()`, `now`↔`spock_now()`, `me`↔`spock_actor()`**.

- **`auth table` anchor** — marks the one identity table (`E045` ≤1 anchor, `E046` single scalar key).
- **`spock_actor()` read seam** — the current actor in fn bodies (mirrors Supabase `auth.uid()`), NULL when anonymous, registered **DIRECTONLY** and **only when an anchor exists** (a body calling it with no anchor fails at load — `E-ACT03`).
- **`= me` write preset** — a field defaults to the current actor, **strong (Hasura-preset) form**: server-stamped, *removed from the client insert/update surface* (GraphQL inputs + generated TS), so a client can't forge an identity column. DIRECTONLY-safe (materialized on the write path, never a DDL DEFAULT).
- **`X-Spock-Actor` impersonation** — a per-request dev header (the seam a verified JWT later fills), resolved anchor-key-type-aware; seed rows are the personas.

### Correctness notes (the non-obvious bits)

- The GraphQL actor rides **`Request::data` per request**, never the schema-global channel — the latter would bleed the previous caller's identity across requests.
- An anonymous insert of a required `= me` column routes to the derived **`<t>_<field>_required` (422)** in `write.rs`, not a raw NOT-NULL 500.
- `spock_actor()` is DIRECTONLY (like `spock_refuse`, **not** `spock_now`): a request-scoped actor must never reach a DEFAULT/CHECK the actor-blind floor evaluates.

### Scope / deferred (named, not forgotten)

Deliberately **not** in this slice: the `/~whoami` + `/~personas` dev endpoints, the G12 lint/scaffold, the dark-write ledger, a `reads_actor` contract bit, and the full fn-param retirement sweep. The seam is **preparatory, not protective**: it makes the *deliberate fn surface* sound and identity columns unforgeable, but per-row read governance, roles, and JWT claims remain v1 (`policy`). The RLS cross-check quantifies exactly this — 58/59 policies are *expressible* with `spock_actor()`, but only enforceable once the floor closes.

### Verification

- `cargo test --workspace` — green (8 test binaries, incl. read-seam, `= me` stamp/anonymous-422, and an end-to-end GraphQL floor test with impersonation headers).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `spock check examples/instagram/v0.spock` — green.
- Live-proven on the dogfood (`user` = `auth table`, `post.author = me`, `archive/delete_post` on `spock_actor()`): `insert_post_one` auto-stamps the author, forging `author` is rejected, anonymous → `post_author_required`, and only the author can archive.

### Commits

1. RFD 0014 + RLS cross-check oracle (design record)
2. `auth table` anchor (lang)
3. `spock_actor()` read seam (runtime)
4. `= me` write preset (both crates)
5. spec + a minimal instagram proof
6. post-review simplifications (`/simplify`)

Spec updated in lockstep (`docs/spec/v0.md`).
