### PR TITLE
topology: adopt uhura as a subsystem via git submodule (no wiring)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "uhura"]
+	path = uhura
+	url = https://github.com/gridaco/uhura.git

--- a/README.md
+++ b/README.md
@@ -626,11 +626,33 @@ prints the SDL for offline schema tooling.
 The npm package metadata lives under `npm/` only to reserve the package name.
 It is not the primary implementation target.
 
+## Uhura, the client language
+
+Spock's doctrine forbids Spock from building a client language — "generate
+types, never the client" (`docs/rfd/0010`), "borrow, don't build"
+(`docs/rfd/0009`). That slot is filled by
+[Uhura](https://github.com/gridaco/uhura): a declarative UI language and
+deterministic headless experience runtime that owns non-authoritative
+UI-session state and experience behavior, with Spock as its canonical
+provider. No fact may be authoritative in both languages.
+
+Uhura is a subsystem of the Spock project: its canonical source lives in its
+own repository and is included here as a git submodule at `uhura/`. Today this
+is topology only — Spock's workspace, build, and CI do not touch the
+submodule, and `cargo` builds work without it (clone with
+`--recurse-submodules` only if you want the Uhura tree). Once Uhura is
+minimally stable, its tooling ships through the unified `spock` toolchain,
+and the runtime integration lands as contract projection plus a provider
+adapter.
+
 ## Repository Layout
 
 - `examples/` contains product requirements and current-valid Spock examples.
 - `docs/rfd/` contains discussion drafts and proposal-only language ideas.
 - `npm/` contains package metadata for npm name reservation.
+- `uhura/` is the Uhura client language (git submodule of
+  [gridaco/uhura](https://github.com/gridaco/uhura); not yet wired into the
+  build).
 
 ## References and prior work
 


### PR DESCRIPTION
## What

Adds [gridaco/uhura](https://github.com/gridaco/uhura) — the client language — as a **git submodule at the repo root** (`uhura/`, pinned at its current `main`), and describes the relationship in the README. This shapes the topology only; there is no build wiring.

Supersedes the direction of #5 (closed): instead of importing uhura's tree as a nested workspace, uhura stays canonical in its own repository and Spock consumes it as a subsystem.

## The setup

- **Spock is the ecosystem and toolchain root.** We own `spock` on npm; `uhura` is taken on both registries and uhura's doctrine publishes nothing standalone. Once uhura is minimally stable, its tooling ships through the unified `spock` toolchain.
- **Uhura stays a distinct language.** Canonical source, spec, checker, runtime, and conformance suite live in gridaco/uhura. The semantic wall holds: no fact may be authoritative in both languages; Spock is uhura's canonical *provider*, and the port seam stays provider-neutral.
- **The doctrine survives:** "generate types, never the client" (RFD 0010) and "borrow, don't build" (RFD 0009) forbid *Spock the language* from building a client language — hosting a sibling's toolchain in the binary is RFD 0010's own "the binary owns generation" applied one level up.

## No wiring yet — explicitly

- Workspace members stay explicit (`crates/spock-lang`, `crates/spock-runtime`, `crates/spock-cli`); cargo does not see the submodule (`cargo metadata` verified clean).
- CI is unaffected — `actions/checkout` does not fetch submodules by default.
- `cargo` builds work without the submodule; `--recurse-submodules` is only needed to get the uhura tree.

The real wiring — spock building/embedding uhura, the contract projection (`spock gen ports`), and the provider adapter — lands in later milestones as uhura stabilizes.

## Changes

- `.gitmodules` + `uhura` gitlink (pinned `0bf91cf`)
- `README.md`: new "Uhura, the client language" section + repository-layout entry