### PR TITLE
Add a reusable Spock agent skill

### DIFF
--- a/.agents/skills/spock-lang
+++ b/.agents/skills/spock-lang
@@ -1,0 +1,1 @@
+../../skills/spock-lang

--- a/.claude/skills/spock-lang
+++ b/.claude/skills/spock-lang
@@ -1,0 +1,1 @@
+../../skills/spock-lang

--- a/skills/spock-lang/SKILL.md
+++ b/skills/spock-lang/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: spock-lang
+description: Build, inspect, validate, run, debug, and modify current Spock v0 backend prototype projects (`*.spock`). Use when turning product requirements into a new Spock program; changing tables, records, functions, seed data, actor-aware operations, storage, or refusals; investigating compiler or runtime behavior; generating contracts, TypeScript, or GraphQL; or verifying Spock-backed Uhura integration.
+---
+
+# Spock Language
+
+Treat the user's request as an executable engineering task. Produce or modify the program, run the relevant Spock commands, fix failures within scope, and finish with concrete verification evidence.
+
+Work against the implemented Spock v0 surface, not proposed syntax. Never invent a `spock init` command, multi-file module system, or future language construct. A new v0 project may be a directory containing a single `app.spock` program.
+
+## Establish the environment
+
+1. Locate the target directory and any existing `.spock` files.
+2. If the target is the Spock source checkout, use its locked Cargo workspace, normative specification, and accepted examples.
+3. If the target is a consumer project, do not assume the Spock source tree or Rust toolchain is present. Use the bundled references and the project's installed, locked, or explicitly requested Spock CLI version.
+4. Preserve unrelated user changes and never replace an existing model before understanding its tables, functions, constraints, seeds, and consumers.
+
+## Select the source of truth
+
+- In the Spock source checkout, read `docs/spec/v0.md` when exact syntax or semantics matter and inspect `crates/spock-lang` when diagnosing the implementation.
+- In that checkout, use `examples/filter-lab/schema.spock`, `examples/instagram-poc/app.spock`, and `examples/instagram/v0.spock` as accepted-language examples.
+- Do not copy syntax from `examples/instagram/v1.spock`, `docs/rfd/0000-vision.spock`, or other paper programs. They explain design direction but do not override the current compiler.
+- In a consumer project, treat the selected CLI plus the bundled references as the usable contract. Record the CLI version when behavior differs from the references.
+- Run the toolchain instead of guessing whether a construct is accepted.
+
+Read the bundled references only as needed:
+
+- Read [references/workflows.md](references/workflows.md) before creating a new project, modifying an existing project, or repairing a failure.
+- Read [references/language.md](references/language.md) before authoring or substantially changing a `.spock` program.
+- Read [references/tooling.md](references/tooling.md) for CLI, generated artifacts, HTTP checks, Studio, storage, or Uhura integration.
+- Read [references/limits.md](references/limits.md) before making security, production-readiness, persistence, policy, or unsupported-feature claims.
+
+## Follow the execution loop
+
+1. Convert the request into observable acceptance scenarios before editing: required data, reads, writes, refusals, actors, storage, and generated consumers.
+2. For a new program, choose keys and relationships before functions, create `app.spock`, then add representative seed data. For an existing program, run a baseline check before changing it whenever the current file is expected to load.
+3. Make the smallest coherent change. Keep durable source rows authoritative and derive display counts or projections in consumers instead of seeding decorative totals.
+4. Run `spock check` after each meaningful change. Fix the earliest diagnostic first and repeat until the whole program materializes and seed replay succeeds.
+5. Run `spock build` or `spock gen` when the contract or a generated consumer changes.
+6. Run the server and probe the exact affected behavior. Cover success and refusal paths, anonymous and actor-bound paths, or storage paths when relevant.
+7. For Spock-backed Uhura work, verify the live provider boundary rather than treating fixture-backed Canvas output as backend proof.
+8. Stop processes started for verification and leave no temporary output in the user's project unless requested.
+9. Report changed files, exact commands, outcomes, unchecked escape count, runtime evidence, and material v0 limitations.
+
+## Preserve the language contract
+
+- Prefer declarative constraints over repeating checks in every function: keys, references, `unique`, closed sets, and validator functions belong on the data.
+- Use references for relationships. A reference stores the target table key and cannot target a composite-key table in v0.
+- Use `auth table` only for the single identity anchor. Treat `X-Spock-Actor` as a forgeable development seam, never authentication.
+- Use `= me` only on a reference to the auth table. Seed rows must still provide required actor-backed fields because seed replay has no actor.
+- Use `storage_object` references for files. Move bytes through `/storage/v1`; never inline bytes in Spock values or function payloads.
+- Keep each `unchecked sql(...)` escape to one statement. Use `:param` placeholders only. The final statement must return columns matching the declared return contract.
+- Mint product refusals in a function `!` clause and raise them with `spock_refuse`. Do not fake derived or reserved errors.
+- Do not introduce `view`, `role`, `policy`, state-machine syntax, modules, native function statements, or other reserved/future syntax.
+
+## Validate proportionally
+
+Every created or modified accepted-language program requires at least:
+
+```sh
+spock check path/to/app.spock
+```
+
+For Spock repository-source work, prefer the current checkout over an older globally installed or npm-cached binary:
+
+```sh
+cargo run --locked -p spock-cli -- check path/to/app.spock
+```
+
+For consumer work, respect the project's locked or explicitly requested version. If none exists, use the current published CLI and record the reported version before interpreting a mismatch.
+
+For runtime work, start the program on an available port, wait for `/~health`, probe the changed read or function path, and stop the process cleanly. Never treat a rendered Studio screen alone as proof of backend behavior.
+
+## Handle diagnostics
+
+- Fix the earliest diagnostic first; later errors may be cascades.
+- Preserve stable `L...` and `E...` codes in reports.
+- If `check` reports unchecked escapes, explain that the contracts and loadability were checked but SQL business logic remains author-asserted.
+- If current source and an npm binary disagree, reproduce with the repository-local CLI before changing the program.

--- a/skills/spock-lang/agents/openai.yaml
+++ b/skills/spock-lang/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Spock Language"
+  short_description: "Create, validate, and modify Spock v0 projects"
+  default_prompt: "Use $spock-lang to create, inspect, validate, debug, or modify a Spock v0 project from these requirements, then prove the result with the relevant CLI and runtime checks."

--- a/skills/spock-lang/references/language.md
+++ b/skills/spock-lang/references/language.md
@@ -132,7 +132,7 @@ Return forms:
 - `t?`: zero or one
 - `[t]`: any number
 
-Every body contains one or more `unchecked sql("...")` escapes. Each escape carries exactly one row statement. Statements execute in order in one transaction; the final statement answers the call. Only `:name` placeholders are accepted, and declared parameters must be used.
+Every body contains one or more `unchecked sql("...")` escapes. Each escape carries exactly one SQL statement. Statements execute in order in one transaction; the final statement answers the call. Only `:name` placeholders are accepted, and declared parameters must be used.
 
 The final result columns must match the declared table or record field names. A scalar return requires one result column. Use `RETURNING` when the answering statement is DML.
 

--- a/skills/spock-lang/references/language.md
+++ b/skills/spock-lang/references/language.md
@@ -1,0 +1,184 @@
+# Spock v0 Language Reference
+
+Use this reference for current accepted syntax. Consult `docs/spec/v0.md` for complete semantics and diagnostic codes.
+
+## Lexical rules
+
+- Files are UTF-8 and conventionally end in `.spock`.
+- Identifiers match `[a-z_][a-z0-9_]*`.
+- Strings support `\"`, `\\`, `\n`, and `\t` escapes.
+- Triple-quoted strings are multiline raw strings with no escape processing.
+- Integers are signed decimal `i64` values. Floats require digits on both sides of `.` and do not support exponents.
+- `//` and `////` or longer are ordinary comments. Exactly `///` documents the next declaration or field. `//!` documents the file and must appear before declarations.
+
+Active keywords:
+
+```text
+table auth record fn mut key unique check seed on delete restrict cascade
+set null text int float bool timestamp uuid auto now me true false
+```
+
+`unchecked` and `sql` are contextual in function bodies. `file` is soft syntax in seed values. Future-reserved words are not accepted as identifiers:
+
+```text
+view role policy error state extern unsafe derived protected module enum
+expect transition upsert match with
+```
+
+## Tables and fields
+
+```spock
+auth table user {
+  key id: uuid = auto
+  username: text unique
+  display_name: text
+}
+
+table post {
+  key id: uuid = auto
+  author: user on delete cascade
+  body: text
+  status: "draft" | "published" = "draft"
+  published_at: timestamp?
+}
+```
+
+Builtins are `text`, `int`, `float`, `bool`, `timestamp`, and `uuid`. A declared table name in type position is a reference that stores the target key. Add `?` for optional values.
+
+Field modifiers must stay in this order:
+
+```text
+[key] name: type [?] [check fn] [unique] [= default]
+[on delete restrict|cascade|set null]
+```
+
+Defaults:
+
+- `auto` on `uuid`
+- `now` on `timestamp`
+- `me` on a reference to the one `auth table`
+- a type-compatible literal
+
+Use a composite key or unique group for multi-field identity:
+
+```spock
+table follow {
+  key (follower, followed)
+  follower: user on delete cascade
+  followed: user on delete cascade
+  at: timestamp = now
+}
+```
+
+References cannot target a composite-key table. `on delete set null` requires an optional reference.
+
+## Constraints and validators
+
+Use a closed set for a stored string choice:
+
+```spock
+status: "draft" | "published" | "archived"
+```
+
+Closed sets are table-field types only in v0. They cannot be keys, record fields, or function parameters.
+
+Use a read function returning `bool` as a value validator:
+
+```spock
+fn nonempty(value: text) -> bool {
+  unchecked sql("SELECT length(trim(:value)) > 0")
+}
+
+table comment {
+  key id: uuid = auto
+  body: text check nonempty
+}
+```
+
+Validator functions have stricter laws: one deterministic, clauseless boolean `SELECT`, matching parameter types, and no writes. Cross-column checks use `check (field_a, field_b) validator` inside the table.
+
+## Records
+
+Records are scalar return shapes for functions, not stored data or parameter types:
+
+```spock
+record post_summary {
+  id: uuid
+  body: text
+  author_name: text
+}
+```
+
+Record fields must be builtin scalars. Do not use keys, references, constraints, defaults, or delete actions inside records.
+
+## Functions
+
+Use `fn` for reads and `mut fn` for operations that may write:
+
+```spock
+fn find_post(id: uuid) -> post? {
+  unchecked sql("SELECT * FROM post WHERE id = :id")
+}
+
+mut fn publish_post(id: uuid) -> post ! not_found {
+  unchecked sql("UPDATE post SET status = 'published' WHERE id = :id")
+  unchecked sql("SELECT * FROM post WHERE id = :id")
+}
+```
+
+Return forms:
+
+- `t`: exactly one row or scalar
+- `t?`: zero or one
+- `[t]`: any number
+
+Every body contains one or more `unchecked sql("...")` escapes. Each escape carries exactly one row statement. Statements execute in order in one transaction; the final statement answers the call. Only `:name` placeholders are accepted, and declared parameters must be used.
+
+The final result columns must match the declared table or record field names. A scalar return requires one result column. Use `RETURNING` when the answering statement is DML.
+
+Mint a product refusal in the signature and raise it conditionally:
+
+```spock
+mut fn follow_user(target: user) -> follow ! cannot_follow_self {
+  unchecked sql("""
+    SELECT spock_refuse('cannot_follow_self')
+    WHERE spock_actor() = :target
+  """)
+  unchecked sql("""
+    INSERT INTO follow (follower, followed)
+    VALUES (spock_actor(), :target)
+    RETURNING *
+  """)
+}
+```
+
+## Seed data
+
+Seed statements execute in file order. Bind rows before referencing them:
+
+```spock
+seed {
+  alice = user {
+    id: "10000000-0000-4000-8000-000000000001",
+    username: "alice",
+    display_name: "Alice"
+  }
+
+  post { author: alice, body: "Hello", status: "published" }
+}
+```
+
+Seed cannot call functions. A binding may only fill a reference to the same target table.
+
+For file-backed seed data, reference the builtin `storage_object` table and use a relative path that stays under the source directory:
+
+```spock
+table photo {
+  key id: uuid = auto
+  image: storage_object
+}
+
+seed {
+  photo { image: file("./seed/photo.jpg") }
+}
+```

--- a/skills/spock-lang/references/limits.md
+++ b/skills/spock-lang/references/limits.md
@@ -1,0 +1,59 @@
+# Spock v0 Boundaries
+
+State these boundaries plainly. Do not imply production guarantees that v0 does not provide.
+
+## Language boundaries
+
+- One source file per program; no modules or cross-file imports.
+- No implemented `view`, `role`, `policy`, state-machine, native statement, effect, or external-service syntax.
+- Function bodies are SQL escapes only. The compiler verifies the contract, statement safety envelope, loadability, parameters, and result shape, but not the business meaning of SQL.
+- Records are function return shapes only. They are not stored and cannot be function parameters.
+- References cannot target composite-key tables.
+- Seed data cannot call functions.
+- No partial or conditional uniqueness.
+- No reusable nominal domain types or curated format types such as `email`.
+
+## Security and identity boundaries
+
+- v0 is an ungoverned prototype tier.
+- `X-Spock-Actor` is forgeable and unverified. It is an impersonation seam for local development, not authentication.
+- Table reads are public. GraphQL table writes and REST function calls are not protected by policy/RLS.
+- `auth table`, `spock_actor()`, and `= me` provide identity plumbing, not authorization.
+- Never describe v0 as secure for multi-tenant or production data.
+
+## Data and runtime boundaries
+
+- The database is recreated on every `run`; there are no migrations.
+- The default database is in memory. `--db` selects a recreated local file, not durable migration-managed storage.
+- REST and GraphQL list reads default to 50 rows and cap at 200.
+- REST tables are read-only. Use GraphQL for derived floor writes and REST RPC for declared functions.
+- Function list returns are uncapped; function authors must apply their own `LIMIT` when appropriate.
+- Storage bytes live in the local runtime. Signing secrets, signed URLs, and objects do not survive a restart.
+- The in-process storage sweeper reclaims abandoned objects; storage is a prototype byte plane, not a production object store.
+
+## Modeling guidance
+
+- Store source facts, not display counters. Derive follower, comment, like, save, and similar counts from relationship rows.
+- Keep private concepts semantically private in consumers even though the v0 open read floor cannot enforce row visibility.
+- Prefer idempotent mutation functions for retryable UI commands.
+- Return the authority echo from a mutation instead of inventing client state.
+- Declare refusals for product rules and preserve constraint-derived errors for data laws.
+
+## Accepted versus speculative inputs
+
+Accepted smoke inputs:
+
+```text
+examples/filter-lab/schema.spock
+examples/instagram-poc/app.spock
+examples/instagram/v0.spock
+```
+
+Do not use these as conformance inputs:
+
+```text
+examples/instagram/v1.spock
+docs/rfd/0000-vision.spock
+```
+
+They intentionally contain future syntax.

--- a/skills/spock-lang/references/limits.md
+++ b/skills/spock-lang/references/limits.md
@@ -26,7 +26,7 @@ State these boundaries plainly. Do not imply production guarantees that v0 does 
 - The database is recreated on every `run`; there are no migrations.
 - The default database is in memory. `--db` selects a recreated local file, not durable migration-managed storage.
 - REST and GraphQL list reads default to 50 rows and cap at 200.
-- REST tables are read-only. Use GraphQL for derived floor writes and REST RPC for declared functions.
+- REST tables are read-only. Use GraphQL for table writes and REST RPC for declared functions.
 - Function list returns are uncapped; function authors must apply their own `LIMIT` when appropriate.
 - Storage bytes live in the local runtime. Signing secrets, signed URLs, and objects do not survive a restart.
 - The in-process storage sweeper reclaims abandoned objects; storage is a prototype byte plane, not a production object store.

--- a/skills/spock-lang/references/tooling.md
+++ b/skills/spock-lang/references/tooling.md
@@ -1,0 +1,123 @@
+# Spock Tooling and Verification
+
+## Select the CLI
+
+Inside the Spock repository, use the current checkout so the compiler matches the source under review:
+
+```sh
+cargo run --locked -p spock-cli -- check app.spock
+```
+
+If a current local debug binary is already built, `target/debug/spock` is equivalent and faster. For a consumer project, first respect any version pinned in its package manifest, lockfile, script, or user request. If the project does not select a version, use the current published package and record the version used:
+
+```sh
+npx --yes spock --version
+npx --yes spock check app.spock
+```
+
+Do not debug a current-source program with an older npm-cached binary. Reproduce disagreements with the repository-local CLI.
+
+Spock v0 does not implement `spock init`. Creating a project means creating the target directory and its single `.spock` program, conventionally `app.spock`.
+
+## Core commands
+
+```sh
+spock check app.spock
+spock build app.spock -o contract.json
+spock gen types app.spock -o contract.ts
+spock gen graphql-schema app.spock -o schema.graphql
+spock run app.spock --port 4000
+spock run app.spock --port 4000 --db /tmp/app.sqlite
+```
+
+`check` is more than syntax checking. It materializes the schema in memory, validates function SQL bodies and return shapes, and replays seed data through the runtime write path.
+
+`run` recreates the selected database and replays seed data on every start. Omit `--db` for an in-memory database.
+
+## Runtime endpoints
+
+After `spock run app.spock --port 4000`:
+
+```text
+GET  /~health
+GET  /~contract
+GET  /~studio
+GET  /~personas
+GET  /~whoami
+GET  /rest/v1/{table}
+GET  /rest/v1/{table}/{id}
+GET  /rest/v1/rpc/{read_fn}
+POST /rest/v1/rpc/{fn}
+GET  /graphql/v1             GraphiQL
+POST /graphql/v1             GraphQL execution
+```
+
+When the contract references `storage_object`, `/storage/v1` is also mounted.
+
+Basic probes:
+
+```sh
+curl -sS http://127.0.0.1:4000/~health
+curl -sS http://127.0.0.1:4000/~contract
+curl -sS 'http://127.0.0.1:4000/rest/v1/post?limit=20'
+curl -sS -X POST http://127.0.0.1:4000/rest/v1/rpc/publish_post \
+  -H 'content-type: application/json' \
+  -H 'X-Spock-Actor: 10000000-0000-4000-8000-000000000001' \
+  --data '{"id":"20000000-0000-4000-8000-000000000001"}'
+```
+
+Use `X-Spock-Actor` only to exercise the v0 development identity seam. Test anonymous behavior by omitting it.
+
+## GraphQL
+
+GraphQL reads and writes are mounted at `/graphql/v1`. GET serves GraphiQL; POST accepts the standard `{query, variables, operationName}` envelope. Introspection is enabled.
+
+List reads default to 50 rows and cap at 200. Generated writes use the same runtime validation and derived errors as seed replay.
+
+For offline tooling:
+
+```sh
+spock gen graphql-schema app.spock -o schema.graphql
+```
+
+## Storage verification
+
+The upload sequence is:
+
+1. `POST /storage/v1/object/upload/sign` to mint a pending object and signed PUT URL.
+2. `PUT` bytes to that URL with a content type.
+3. Attach the returned object id through a normal table write or function.
+4. `POST /storage/v1/object/sign/{id}` to mint a signed GET URL.
+5. `GET` the signed URL and verify bytes and content type.
+
+Signed URLs and stored objects are local to one run. Do not persist or expose them as durable product URLs.
+
+## Spock and Uhura together
+
+For the checked-in Instagram proof of concept, run both processes with the repository launcher:
+
+```sh
+./scripts/spock-uhura.sh \
+  examples/instagram-poc/app.spock \
+  uhura/examples/instagram-uhura
+```
+
+Then verify:
+
+```text
+http://127.0.0.1:8787/          Uhura Editor
+http://127.0.0.1:8787/play      live Uhura Play
+http://127.0.0.1:4000/~studio   Spock Studio
+```
+
+Stop old servers before using the default ports. If only the Uhura port is occupied, pass `--uhura-port`; changing the Spock port also requires matching provider configuration.
+
+## Completion checklist
+
+- Run `spock check` on every changed accepted-language file.
+- Run focused Rust tests when changing compiler or runtime code.
+- Run `cargo test --workspace --locked` for broad Spock changes.
+- Regenerate and inspect the contract, TypeScript, or GraphQL schema when their surface changes.
+- Probe the exact runtime path affected by the task.
+- For Uhura integration, verify Editor, Play, actor switching, at least one read, and at least one relevant command.
+- Record unchecked escape counts and prototype limitations in the handoff.

--- a/skills/spock-lang/references/tooling.md
+++ b/skills/spock-lang/references/tooling.md
@@ -59,14 +59,11 @@ Basic probes:
 ```sh
 curl -sS http://127.0.0.1:4000/~health
 curl -sS http://127.0.0.1:4000/~contract
-curl -sS 'http://127.0.0.1:4000/rest/v1/post?limit=20'
-curl -sS -X POST http://127.0.0.1:4000/rest/v1/rpc/publish_post \
-  -H 'content-type: application/json' \
-  -H 'X-Spock-Actor: 10000000-0000-4000-8000-000000000001' \
-  --data '{"id":"20000000-0000-4000-8000-000000000001"}'
+curl -sS http://127.0.0.1:4000/~personas
+curl -sS http://127.0.0.1:4000/~whoami
 ```
 
-Use `X-Spock-Actor` only to exercise the v0 development identity seam. Test anonymous behavior by omitting it.
+Inspect `/~contract` before constructing table or RPC probes. Use only table names, function names, parameter shapes, and actor ids declared by the target program. Use `X-Spock-Actor` only to exercise the v0 development identity seam, and test anonymous behavior by omitting it.
 
 ## GraphQL
 

--- a/skills/spock-lang/references/workflows.md
+++ b/skills/spock-lang/references/workflows.md
@@ -1,0 +1,126 @@
+# Spock Project Workflows
+
+Use these workflows to turn a product request into a verified Spock v0 program or to modify an existing program safely.
+
+## Contents
+
+- [Define the task contract](#define-the-task-contract)
+- [Create a new project](#create-a-new-project)
+- [Modify an existing project](#modify-an-existing-project)
+- [Diagnose and repair a failure](#diagnose-and-repair-a-failure)
+- [Choose verification scenarios](#choose-verification-scenarios)
+- [Report completion](#report-completion)
+
+## Define the task contract
+
+Extract observable requirements before modeling:
+
+1. Durable entities and their identities.
+2. Relationships and delete behavior.
+3. The one identity-bearing entity, if actor behavior exists.
+4. Stored facts versus derived presentation values.
+5. Required reads and their cardinality: one, optional, or list.
+6. Required writes, retry behavior, and authority echoes.
+7. Product refusals versus constraint-derived errors.
+8. Representative seed scenarios.
+9. File or media fields that require storage.
+10. Generated contract, TypeScript, GraphQL, or Uhura consumers.
+
+Turn each requirement into a scenario with a request and an observable result. Do not treat a schema that merely compiles as proof that a product rule works.
+
+## Create a new project
+
+Spock v0 has no `spock init` command and no implemented module system. Unless the user specifies another layout, create a target directory with one `app.spock` source file.
+
+Follow this order:
+
+1. Confirm the target directory and avoid overwriting existing files.
+2. Select the CLI as described in `references/tooling.md`.
+3. Define tables from durable facts:
+   - choose stable keys;
+   - use references for relationships;
+   - use composite keys for relationship identity when appropriate;
+   - add delete actions deliberately;
+   - encode closed choices and reusable validators as constraints.
+4. Add an `auth table` only when the program needs an actor. Use at most one.
+5. Define records only for scalar function return projections.
+6. Define reads with `fn` and writes with `mut fn`. Declare return cardinality and product refusals explicitly. Never raise derived or reserved codes such as `not_found` with `spock_refuse`; choose a product-specific code such as `task_unavailable`, or let the runtime produce its derived error through the corresponding mechanism.
+7. Add seed rows that cover the important relationships and function scenarios. Provide actor-backed required fields explicitly because seed replay is actorless.
+8. Run `spock check app.spock` and fix diagnostics until it succeeds.
+9. Build the contract and generate requested consumer artifacts.
+10. Start the runtime and execute the relevant scenario matrix below.
+
+Do not add package manifests, framework boilerplate, migrations, or multiple source files unless another tool in the user's project genuinely requires them.
+
+## Modify an existing project
+
+Preserve the existing model and prove both the baseline and the requested delta.
+
+1. Find all `.spock` files and determine which one is executed by scripts, documentation, or consumers.
+2. Read the complete target program before editing. Inventory:
+   - tables, keys, references, and delete actions;
+   - records and return projections;
+   - read and mutation functions;
+   - refusals and constraint-derived errors;
+   - seed bindings and their order;
+   - storage references;
+   - generated artifacts and Uhura ports.
+3. Run the existing check command before editing when the program is expected to be healthy. Record pre-existing failures instead of attributing them to the requested change.
+4. Identify the smallest affected surface and its consumers.
+5. Apply the requested change without reformatting unrelated declarations or replacing accepted syntax with proposed syntax.
+6. Run `check` immediately. Fix the earliest new diagnostic first.
+7. Regenerate artifacts only when their source contract changes. Inspect the resulting diff.
+8. Run focused runtime scenarios for the changed behavior and at least one nearby regression path.
+9. Preserve unrelated working-tree changes and temporary runtime data.
+
+For a schema change, review seed data, function SQL result shapes, REST/GraphQL exposure, generated types, and Uhura port expectations. A table edit is rarely isolated to the table declaration.
+
+## Diagnose and repair a failure
+
+1. Reproduce the failure with the same CLI version and command used by the project.
+2. If source and a published package disagree, reproduce once with the Spock repository-local CLI before changing accepted syntax.
+3. Fix the earliest compiler diagnostic first; parse failures commonly cause cascades.
+4. Use stable diagnostic codes and source spans when reporting the cause.
+5. For `check` failures, distinguish:
+   - lexing or parsing;
+   - name and type checking;
+   - schema materialization;
+   - SQL preparation or result-shape validation;
+   - constraint or seed replay failure.
+6. For runtime failures, capture the route, method, actor header, request body, status, and response body.
+7. Make the narrowest repair, rerun the original reproduction, then run a nearby success or regression scenario.
+8. Do not silence a product rule by deleting a constraint or refusal unless the user requested that semantic change.
+
+## Choose verification scenarios
+
+Use every row that applies to the task.
+
+| Changed surface | Required proof |
+| --- | --- |
+| Tables, fields, references, constraints, or seeds | `spock check`; confirm full schema materialization and seed replay |
+| Read function | Call the read route; verify cardinality, returned fields, ordering, filtering, and empty behavior |
+| Mutation function | Call a success case and every affected declared refusal; verify the returned authority echo |
+| Retryable mutation | Repeat the same request and verify the intended idempotent or refusal behavior |
+| Actor-aware behavior | Exercise anonymous and `X-Spock-Actor` requests with at least two relevant actors |
+| GraphQL surface | Generate or inspect the schema and execute the affected query or mutation |
+| Generated TypeScript | Regenerate the file and inspect the public type diff |
+| Storage reference | Sign upload, upload bytes, attach the object, sign download, and verify bytes and content type |
+| Delete action | Delete or simulate the parent operation and verify `restrict`, `cascade`, or `set null` behavior |
+| Spock-backed Uhura | Verify Editor, live Play, Studio, actor switching, one affected read, and one affected command |
+| Compiler or runtime implementation | Run focused Rust tests, then broader workspace tests proportional to the change |
+
+`spock check` proves that the program loads, SQL statements satisfy the checked envelope, and seeds replay. It does not prove that unchecked SQL expresses the intended business meaning. Runtime scenarios supply that missing evidence.
+
+## Report completion
+
+Provide a compact handoff containing:
+
+1. Files created or modified.
+2. Product behavior implemented or repaired.
+3. Exact validation and runtime commands.
+4. Outcomes, including the table, record, function, seed-row, and unchecked-escape counts reported by the CLI when available.
+5. Runtime request and response evidence for affected paths.
+6. Generated artifacts changed or intentionally left unchanged.
+7. Relevant v0 limitations, security boundaries, or remaining failures.
+
+Never report completion while required checks are failing, a started runtime is still unmanaged, or the result depends on future syntax.


### PR DESCRIPTION
## Summary

- turn the empty `skills/spock-lang` placeholder into a reusable English Agent Skill
- document the implemented Spock v0 language, project workflows, CLI/runtime verification, and prototype boundaries
- make the canonical skill discoverable from Codex and Claude Code through repository-scoped symlinks
- add Codex UI metadata and a default invocation prompt

## Why

The repository had a skill placeholder, but agents had no executable workflow for creating, validating, debugging, or safely modifying a Spock project. A plain `skills/` directory is also not discovered automatically by repository-scoped Codex or Claude Code sessions unless it is installed as a plugin.

This keeps one canonical skill at `skills/spock-lang` and exposes it through:

- `.agents/skills/spock-lang` for Codex
- `.claude/skills/spock-lang` for Claude Code

## Behavior

The skill now directs an agent to:

- model product requirements using only the implemented v0 surface
- create a single-file `app.spock` project without inventing an init command or future syntax
- baseline and minimally modify existing programs
- run `check`, regenerate consumer artifacts, and probe affected runtime behavior
- verify actor, refusal, storage, GraphQL, and Spock-backed Uhura paths when relevant
- report exact evidence and current v0 limitations

## Validation

- skill structure validation through the project skill creator for the canonical, Codex, and Claude Code paths
- English-only content and clean diff checks
- `cargo fmt --all -- --check`
- `cargo test --workspace --locked` — 203 tests passed
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- accepted program checks:
  - `examples/filter-lab/schema.spock`
  - `examples/instagram-poc/app.spock`
  - `examples/instagram/v0.spock`
- temporary new-project and existing-project modification smoke tests, including contract/TypeScript/GraphQL generation
- runtime probes covering health, anonymous refusal, actor success, product refusal, and successful mutation

## Scope

The dirty Uhura submodule contains separate local work and is intentionally excluded from this pull request.