### PR TITLE
Add metadata-driven Studio row insertion

### DIFF
--- a/crates/spock-runtime/studio/FEEDBACK.md
+++ b/crates/spock-runtime/studio/FEEDBACK.md
@@ -1,0 +1,104 @@
+# Studio write-form feedback
+
+This file records gaps exposed by exercising Studio's metadata-driven insert
+sheet against the compiled contract, GraphQL floor, REST query surface, and
+storage gate. It follows the repository's fixture-feedback convention: each
+finding states the current evidence, names the component that owns the close,
+and gives a concrete completion condition.
+
+Tags `S1`–`S6` belong to this file. "Owner" means where the design or
+implementation decision belongs; it does not imply that Studio should paper
+over a missing contract fact.
+
+**Disposition (July 2026): all deferred.** The current Studio and protocol
+behavior is locked for this milestone. Reopen a finding only as explicit work
+owned by the component named below.
+
+## Owner index
+
+| Finding | Owner | State |
+| --- | --- | --- |
+| S1 · canonical reference labels | Studio presentation + compiled contract | deferred design |
+| S2 · scalable reference lookup | Studio, using the existing query protocol | deferred implementation |
+| S3 · structured validator hints | value-constraint contract | deferred design |
+| S4 · explicit NULL on defaulted insert | GraphQL/write semantics | locked v0 semantics |
+| S5 · 64-bit integers on the GraphQL/browser wire | GraphQL scalar mapping | deferred conformance work |
+| S6 · persisted upload filename | storage protocol implementation | deferred implementation |
+
+## Findings
+
+**S1 · Generic references have no canonical display label.** The actor picker
+has a protocol-defined `label`, but a normal reference carries only its target
+table and key. Studio currently chooses the first unique non-key text field,
+then the first non-key text field, then the key. That keeps the picker useful,
+but it is a presentation heuristic, not contract truth.
+
+→ **Owner:** Studio presentation in
+[`docs/rfd/0015-studio.md`](../../../docs/rfd/0015-studio.md), with any authored
+or derived marker added to the compiled-contract IR in
+[`crates/spock-lang/src/ir.rs`](../../spock-lang/src/ir.rs). Because the v0
+contract is additive, a marker must be optional. Close when all contract
+consumers can select the same authoritative label without guessing.
+
+**S2 · The reference picker loads one capped page.** Studio currently requests
+at most 200 target rows and cannot search or page within the sheet. This is
+primarily Studio debt, not a missing basic query contract: REST already exposes
+`limit`, `offset`, filters, and total ordering. Exact counts and a safe compound
+keyset remain protocol-level gaps already evidenced by
+[`filter-lab` F7 and F1](../../../examples/filter-lab/FEEDBACK.md).
+
+→ **Owner:**
+[`src/views/insert-row-sheet.tsx`](src/views/insert-row-sheet.tsx), using the
+query layer specified by
+[`docs/rfd/0021-filter.md`](../../../docs/rfd/0021-filter.md). Close the Studio
+part with debounced server search, offset paging, stale-request cancellation,
+and a way to select every reachable row. Do not invent an ad-hoc keyset cursor.
+
+**S3 · A `check` names a validator but does not describe its controls.** The
+contract can tell Studio that `valid_username` validates a field, but not that
+the underlying rules are a length bound, pattern, numeric range, or a
+conjunction. Studio can name the validator and surface its server error; it
+cannot honestly derive `min`, `max`, or `pattern` attributes from arbitrary
+validator SQL.
+
+→ **Owner:** the value-constraint contract in
+[`docs/rfd/0013-value-constraints.md`](../../../docs/rfd/0013-value-constraints.md).
+Close only with an explicit additive hint/structured-constraint design; parsing
+validator SQL in Studio is not a valid close.
+
+**S4 · A defaulted optional field cannot be inserted explicitly as SQL NULL.**
+Insert semantics intentionally treat `null` as absence, so omission and
+explicit `null` both apply the default. Update has the distinct operation
+needed to clear the field afterward, but a one-step insert cannot express it.
+
+→ **Owner:** the normative write rules in
+[`docs/spec/v0.md`](../../../docs/spec/v0.md) §5.1 and
+[`docs/spec/graphql.md`](../../../docs/spec/graphql.md) §5. This is already a
+declared v0 limitation, not a Studio bug. Close only with an unambiguous wire
+representation that preserves GraphQL's unprovided-variable semantics.
+
+**S5 · Spock `int` is wider than both GraphQL `Int` and an exactly representable
+browser number.** The language/storage contract is signed 64-bit, GraphQL
+currently exposes the built-in 32-bit `Int`, and JavaScript `number` is exact
+only through `2^53 - 1`. Studio rejects unsafe JavaScript integers to prevent
+silent rounding, but values outside the GraphQL range can still fail at the
+wire boundary.
+
+→ **Owner:** scalar mapping in
+[`docs/spec/graphql.md`](../../../docs/spec/graphql.md) and
+[`crates/spock-runtime/src/graphql.rs`](../src/graphql.rs). Close by choosing a
+truthful end-to-end representation (for example a custom 64-bit scalar/string
+wire, or a deliberately narrower language type), then pin boundary tests and
+generated TypeScript behavior.
+
+**S6 · Browser-uploaded filenames are session-only.** The accepted storage
+schema says `storage_object.name` is the original filename, but the mint request
+accepts no filename and the signed PUT currently persists only content type,
+size, and checksum. Studio can show `File.name` immediately after upload; a
+later session may have only the object id.
+
+→ **Owner:** the storage protocol and handler in
+[`docs/rfd/0018-storage.md`](../../../docs/rfd/0018-storage.md) and
+[`crates/spock-runtime/src/storage/mod.rs`](../src/storage/mod.rs). Close when a
+defined, safely handled filename travels through mint or a signature-bound PUT
+header, is persisted to `storage_object.name`, and is covered by storage tests.

--- a/crates/spock-runtime/studio/README.md
+++ b/crates/spock-runtime/studio/README.md
@@ -75,6 +75,12 @@ whose last segment has a file extension stays a genuine 404, so a broken
 `script`/`link` src still fails loudly). The impersonated **Actor** is a session
 toggle, not part of the URL — a reload restores the view but resets to anonymous.
 
+## Feedback
+
+Write-form gaps found while exercising the compiled contract are tracked in
+[`FEEDBACK.md`](FEEDBACK.md), with each finding assigned to its contract,
+protocol, runtime, or Studio owner.
+
 ## Theme
 
 The design system is the shadcn **Mira** style + **neutral** (monochrome) theme,

--- a/crates/spock-runtime/studio/src/app.tsx
+++ b/crates/spock-runtime/studio/src/app.tsx
@@ -17,6 +17,11 @@ import {
 } from "lucide-react"
 
 import { api } from "@/lib/api"
+import {
+  actorFromSelectValue,
+  actorSelectValue,
+  ANONYMOUS_ACTOR_SELECT_VALUE,
+} from "@/lib/actor"
 import { AppContext } from "@/lib/app-context"
 import type { AppState, StatusContent } from "@/lib/app-context"
 import { pathToRoute, routeTitle, routeToPath, samePath } from "@/lib/router"
@@ -43,8 +48,6 @@ import { RecordView } from "@/views/record-view"
 import { StorageView } from "@/views/storage-view"
 import { TableView } from "@/views/table-view"
 import { TablesOverview } from "@/views/tables-overview"
-
-const ANON = "__anon__"
 
 // Prefer classes over hooks for the pages/orchestrator (studio/README.md): the
 // root owns all shared state and exposes it through AppContext. Views are
@@ -86,8 +89,7 @@ export default class App extends Component<Record<string, never>, AppData> {
       return
     }
     this.setState({ contract: c.body as Contract })
-    const p = await api("/~personas", null)
-    this.setState({ personas: (p.body as Persona[]) ?? [] })
+    await this.refreshPersonas()
     void this.refreshWhoami()
   }
 
@@ -104,6 +106,13 @@ export default class App extends Component<Record<string, never>, AppData> {
   private refreshWhoami = async () => {
     const r = await api("/~whoami", this.state.actor)
     this.setState({ whoami: r.body as WhoAmI })
+  }
+
+  private refreshPersonas = async () => {
+    const response = await api("/~personas", null)
+    if (response.status === 200) {
+      this.setState({ personas: normalizePersonas(response.body) })
+    }
   }
 
   // A user clicked something: push the target onto history (skipping a no-op
@@ -138,6 +147,7 @@ export default class App extends Component<Record<string, never>, AppData> {
     const ctx: AppState = {
       contract,
       personas,
+      refreshPersonas: this.refreshPersonas,
       actor,
       setActor: this.setActor,
       route,
@@ -536,25 +546,27 @@ function Topbar({
         <User size={14} className="text-muted-foreground" />
         <span className="text-xs text-muted-foreground">Actor</span>
         <Select
-          value={actor ?? ANON}
-          onValueChange={(v) => setActor(v === ANON ? null : (v as string))}
+          value={actorSelectValue(actor)}
+          onValueChange={(value) => setActor(actorFromSelectValue(value))}
         >
           <SelectTrigger
             size="sm"
             className="border-0 bg-transparent dark:bg-transparent shadow-none font-medium focus-visible:ring-0"
           >
             <SelectValue>
-              {(value: unknown) =>
-                value === ANON || value == null
+              {(value: unknown) => {
+                const selectedActor = actorFromSelectValue(value)
+                return selectedActor === null
                   ? "anonymous"
-                  : (personas.find((p) => p.actor === value)?.label ?? String(value))
-              }
+                  : (personas.find((persona) => persona.actor === selectedActor)?.label ??
+                      selectedActor)
+              }}
             </SelectValue>
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value={ANON}>anonymous</SelectItem>
+            <SelectItem value={ANONYMOUS_ACTOR_SELECT_VALUE}>anonymous</SelectItem>
             {personas.map((p) => (
-              <SelectItem key={p.actor} value={p.actor}>
+              <SelectItem key={p.actor} value={actorSelectValue(p.actor)}>
                 {p.label}
               </SelectItem>
             ))}
@@ -577,8 +589,9 @@ function WhoAmIBadge({ whoami, personas }: { whoami: WhoAmI | null; personas: Pe
       </span>
     )
   }
+  const actor = actorHeaderValue(whoami.actor)
   const label =
-    personas.find((p) => p.actor === whoami.actor)?.label ??
+    personas.find((p) => p.actor === actor)?.label ??
     (typeof whoami.actor === "string" ? whoami.actor.slice(0, 8) + "…" : String(whoami.actor))
   return (
     <span className="text-xs font-mono px-2.5 py-1 rounded-full border flex items-center gap-1.5 whitespace-nowrap">
@@ -589,6 +602,26 @@ function WhoAmIBadge({ whoami, personas }: { whoami: WhoAmI | null; personas: Pe
       {whoami.known ? <Check size={12} /> : <span className="text-destructive">unknown</span>}
     </span>
   )
+}
+
+// /~personas exposes the anchor key in its native JSON scalar type. Studio's
+// actor state is the exact textual value sent in X-Spock-Actor, so normalize at
+// the API boundary before feeding values to the string-valued Select controls.
+function normalizePersonas(body: unknown): Persona[] {
+  if (!Array.isArray(body)) return []
+  return body.flatMap((value) => {
+    if (typeof value !== "object" || value === null) return []
+    const { actor, label } = value as { actor?: unknown; label?: unknown }
+    const normalizedActor = actorHeaderValue(actor)
+    if (normalizedActor === null || typeof label !== "string") return []
+    return [{ actor: normalizedActor, label }]
+  })
+}
+
+function actorHeaderValue(actor: unknown): string | null {
+  return typeof actor === "string" || typeof actor === "number" || typeof actor === "boolean"
+    ? String(actor)
+    : null
 }
 
 // --- status bar ------------------------------------------------------------

--- a/crates/spock-runtime/studio/src/components/ui/sheet.tsx
+++ b/crates/spock-runtime/studio/src/components/ui/sheet.tsx
@@ -1,0 +1,146 @@
+import * as React from "react"
+import { Dialog as SheetPrimitive } from "@base-ui/react/dialog"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function Sheet({ ...props }: SheetPrimitive.Root.Props) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger({ ...props }: SheetPrimitive.Trigger.Props) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose({ ...props }: SheetPrimitive.Close.Props) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal({ ...props }: SheetPrimitive.Portal.Props) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({ className, ...props }: SheetPrimitive.Backdrop.Props) {
+  return (
+    <SheetPrimitive.Backdrop
+      data-slot="sheet-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/40 transition-opacity duration-200 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-[1px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: SheetPrimitive.Popup.Props & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Popup
+        data-slot="sheet-content"
+        className={cn(
+          "fixed inset-y-0 right-0 z-50 flex h-full w-full flex-col border-l bg-background text-xs/relaxed text-foreground shadow-xl transition-transform duration-200 ease-out data-ending-style:translate-x-full data-starting-style:translate-x-full sm:w-3/4 sm:max-w-2xl",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <SheetPrimitive.Close
+            data-slot="sheet-close"
+            render={
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className="absolute top-3.5 right-3.5 z-10"
+              />
+            }
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Popup>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn(
+        "flex shrink-0 flex-col gap-1.5 border-b px-5 py-4 pr-12",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetBody({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-body"
+      className={cn("min-h-0 flex-1 overflow-y-auto px-5 py-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn(
+        "mt-auto flex shrink-0 items-center justify-end gap-2 border-t bg-background px-5 py-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({ className, ...props }: SheetPrimitive.Title.Props) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("font-heading text-sm font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: SheetPrimitive.Description.Props) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-xs/relaxed text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetBody,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/crates/spock-runtime/studio/src/components/ui/textarea.tsx
+++ b/crates/spock-runtime/studio/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "min-h-20 w-full min-w-0 resize-y rounded-md border border-input bg-input/20 px-2.5 py-2 text-sm transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 md:text-xs/relaxed dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/crates/spock-runtime/studio/src/lib/actor.ts
+++ b/crates/spock-runtime/studio/src/lib/actor.ts
@@ -1,0 +1,28 @@
+// Select values share one string namespace, while an auth anchor may itself
+// use any string as a key. Tag actor options structurally so no legal key can
+// collide with Studio's anonymous choice.
+export const ANONYMOUS_ACTOR_SELECT_VALUE = '["anonymous"]'
+
+export function actorSelectValue(actor: string | null): string {
+  return actor === null
+    ? ANONYMOUS_ACTOR_SELECT_VALUE
+    : JSON.stringify(["actor", actor])
+}
+
+export function actorFromSelectValue(value: unknown): string | null {
+  if (typeof value !== "string") return null
+
+  let decoded: unknown
+  try {
+    decoded = JSON.parse(value)
+  } catch {
+    return null
+  }
+
+  return Array.isArray(decoded) &&
+    decoded.length === 2 &&
+    decoded[0] === "actor" &&
+    typeof decoded[1] === "string"
+    ? decoded[1]
+    : null
+}

--- a/crates/spock-runtime/studio/src/lib/api.ts
+++ b/crates/spock-runtime/studio/src/lib/api.ts
@@ -13,7 +13,7 @@ export async function api(
   opts: RequestInit = {},
 ): Promise<ApiResult> {
   const headers = new Headers(opts.headers)
-  if (actor) headers.set("X-Spock-Actor", actor)
+  if (actor !== null) headers.set("X-Spock-Actor", actor)
   let res: Response
   let text = ""
   try {

--- a/crates/spock-runtime/studio/src/lib/app-context.ts
+++ b/crates/spock-runtime/studio/src/lib/app-context.ts
@@ -10,6 +10,7 @@ export interface StatusContent {
 export interface AppState {
   contract: Contract
   personas: Persona[]
+  refreshPersonas: () => Promise<void>
   actor: string | null
   setActor: (a: string | null) => void
   route: Route

--- a/crates/spock-runtime/studio/src/lib/graphql-mutations.ts
+++ b/crates/spock-runtime/studio/src/lib/graphql-mutations.ts
@@ -1,0 +1,222 @@
+import { api } from "@/lib/api"
+import type { Table } from "@/types"
+
+const GRAPHQL_PATH = "/graphql/v1"
+
+export type RowInput = Readonly<Record<string, unknown>>
+
+export interface GraphQLErrorExtensions {
+  code?: string
+  kind?: string
+  table?: string | null
+  fields?: string[]
+  [key: string]: unknown
+}
+
+export interface GraphQLErrorLocation {
+  line: number
+  column: number
+}
+
+export interface GraphQLErrorDetail {
+  message: string
+  locations?: GraphQLErrorLocation[]
+  path?: (string | number)[]
+  extensions?: GraphQLErrorExtensions
+}
+
+export interface SingleRowMutationResult {
+  __typename: string
+}
+
+/**
+ * A normalized GraphQL/transport failure. Contract errors are available both
+ * in `errors` and as convenient top-level properties for form-level handling.
+ */
+export class GraphQLMutationError extends Error {
+  readonly status: number
+  readonly errors: readonly GraphQLErrorDetail[]
+  readonly code: string
+  readonly kind?: string
+  readonly table?: string | null
+  readonly fields: readonly string[]
+
+  constructor(status: number, errors: readonly GraphQLErrorDetail[], fallback: string) {
+    const messages = [...new Set(errors.map((error) => error.message.trim()).filter(Boolean))]
+    super(messages.join("; ") || fallback)
+    this.name = "GraphQLMutationError"
+    this.status = status
+    this.errors = errors
+
+    const extensions = errors[0]?.extensions
+    this.code = extensions?.code ?? "graphql_error"
+    this.kind = extensions?.kind
+    this.table = extensions?.table
+    this.fields = extensions?.fields ?? []
+  }
+}
+
+/** Insert one row through the GraphQL floor, letting omitted defaults apply. */
+export function insertRow(
+  table: Table,
+  object: RowInput,
+  actor: string | null,
+): Promise<SingleRowMutationResult> {
+  const name = table.name
+  const query = `mutation StudioInsert_${name}($object: ${name}_insert_input!) {
+    result: insert_${name}_one(object: $object) {
+      __typename
+    }
+  }`
+
+  return executeSingleRowMutation(query, { object }, actor)
+}
+
+/** Update one row by its (possibly composite) key. Omitted `_set` fields stay unchanged. */
+export function updateRow(
+  table: Table,
+  pkColumns: RowInput,
+  changes: RowInput,
+  actor: string | null,
+): Promise<SingleRowMutationResult> {
+  const name = table.name
+  const query = `mutation StudioUpdate_${name}(
+    $pkColumns: ${name}_pk_columns_input!
+    $set: ${name}_set_input!
+  ) {
+    result: update_${name}_by_pk(pk_columns: $pkColumns, _set: $set) {
+      __typename
+    }
+  }`
+
+  return executeSingleRowMutation(query, { pkColumns, set: changes }, actor)
+}
+
+async function executeSingleRowMutation(
+  query: string,
+  variables: Readonly<Record<string, unknown>>,
+  actor: string | null,
+): Promise<SingleRowMutationResult> {
+  const response = await api(GRAPHQL_PATH, actor, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ query, variables }),
+  })
+
+  const errors = responseErrors(response.body)
+  if (errors.length > 0) {
+    throw new GraphQLMutationError(response.status, errors, "GraphQL mutation failed")
+  }
+
+  if (response.status < 200 || response.status >= 300) {
+    const error = transportError(response.status, response.body)
+    throw new GraphQLMutationError(response.status, [error], error.message)
+  }
+
+  const result = mutationResult(response.body)
+  if (!result) {
+    const error: GraphQLErrorDetail = {
+      message: "GraphQL mutation returned an invalid response",
+      extensions: { code: "invalid_response" },
+    }
+    throw new GraphQLMutationError(response.status, [error], error.message)
+  }
+
+  return result
+}
+
+function responseErrors(body: unknown): GraphQLErrorDetail[] {
+  if (!isRecord(body) || !Array.isArray(body.errors)) return []
+  return body.errors.map(normalizeGraphQLError)
+}
+
+function normalizeGraphQLError(value: unknown): GraphQLErrorDetail {
+  if (!isRecord(value)) return { message: "GraphQL mutation failed" }
+
+  const error: GraphQLErrorDetail = {
+    message: typeof value.message === "string" ? value.message : "GraphQL mutation failed",
+  }
+  const locations = normalizeLocations(value.locations)
+  const path = normalizePath(value.path)
+  const extensions = normalizeExtensions(value.extensions)
+  if (locations) error.locations = locations
+  if (path) error.path = path
+  if (extensions) error.extensions = extensions
+  return error
+}
+
+function normalizeLocations(value: unknown): GraphQLErrorLocation[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const locations = value.flatMap((location) => {
+    if (
+      !isRecord(location) ||
+      typeof location.line !== "number" ||
+      typeof location.column !== "number"
+    ) {
+      return []
+    }
+    return [{ line: location.line, column: location.column }]
+  })
+  return locations.length > 0 ? locations : undefined
+}
+
+function normalizePath(value: unknown): (string | number)[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const path = value.filter((part): part is string | number => {
+    return typeof part === "string" || typeof part === "number"
+  })
+  return path.length > 0 ? path : undefined
+}
+
+function normalizeExtensions(value: unknown): GraphQLErrorExtensions | undefined {
+  if (!isRecord(value)) return undefined
+
+  const extensions: GraphQLErrorExtensions = {}
+  for (const [key, item] of Object.entries(value)) {
+    if (key !== "code" && key !== "kind" && key !== "table" && key !== "fields") {
+      extensions[key] = item
+    }
+  }
+  if (typeof value.code === "string") extensions.code = value.code
+  if (typeof value.kind === "string") extensions.kind = value.kind
+  if (typeof value.table === "string" || value.table === null) extensions.table = value.table
+  if (Array.isArray(value.fields) && value.fields.every((field) => typeof field === "string")) {
+    extensions.fields = value.fields
+  }
+  return extensions
+}
+
+function transportError(status: number, body: unknown): GraphQLErrorDetail {
+  const fallback =
+    status === 0 ? "Unable to reach the GraphQL endpoint" : `GraphQL request failed (HTTP ${status})`
+
+  if (!isRecord(body) || !isRecord(body.error)) {
+    return {
+      message: fallback,
+      extensions: { code: status === 0 ? "network" : "http_error" },
+    }
+  }
+
+  return {
+    message: typeof body.error.message === "string" ? body.error.message : fallback,
+    extensions: {
+      code:
+        typeof body.error.code === "string"
+          ? body.error.code
+          : status === 0
+            ? "network"
+            : "http_error",
+      ...(typeof body.error.kind === "string" ? { kind: body.error.kind } : {}),
+    },
+  }
+}
+
+function mutationResult(body: unknown): SingleRowMutationResult | null {
+  if (!isRecord(body) || !isRecord(body.data) || !isRecord(body.data.result)) return null
+  const typename = body.data.result.__typename
+  return typeof typename === "string" ? { __typename: typename } : null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}

--- a/crates/spock-runtime/studio/src/lib/query.ts
+++ b/crates/spock-runtime/studio/src/lib/query.ts
@@ -16,7 +16,7 @@ export type Arity = "value" | "pattern" | "list" | "unary"
 export interface OpDef {
   key: string
   label: string
-  // the PostgREST/SQL-ish symbol shown in the operator menu, Supabase-style
+  // the PostgREST/SQL-ish symbol shown in the operator menu
   symbol: string
   arity: Arity
 }
@@ -55,7 +55,7 @@ export interface SortRule {
 // The REST value for one rule, e.g. `eq.7`, `ilike.%foo%`, `in.(a,b)`,
 // `is.null`, `not.is.null`. Returns null for an incomplete rule (no column, or
 // a value-taking op with an empty value) so half-typed filters simply don't
-// apply — mirroring Supabase, which never sends an incomplete filter.
+// apply; incomplete filters are never sent.
 export function restValue(rule: FilterRule): string | null {
   if (!rule.column) return null
   const arity = opDef(rule.op).arity
@@ -97,7 +97,7 @@ export function isActiveRule(rule: FilterRule): boolean {
   return restValue(rule) !== null
 }
 
-// Closed-set columns get a value dropdown (Supabase renders enums as selects);
+// Closed-set columns get a value dropdown;
 // everything else is a free-text value.
 export function setValues(type: TypeRef | undefined): string[] | null {
   return type?.kind === "set" ? (type.values ?? []) : null

--- a/crates/spock-runtime/studio/src/lib/storage.ts
+++ b/crates/spock-runtime/studio/src/lib/storage.ts
@@ -1,6 +1,6 @@
 // The storage gate (RFD 0018), from the console's side. Studio drives the same
-// Supabase-shaped `/storage/v1` endpoints any client would: mint a signed
-// upload URL, PUT the bytes, then (for the in-row case) attach the object id to
+// `/storage/v1` endpoints any client would: mint a signed upload URL, PUT the
+// bytes, then (for the in-row case) attach the object id to
 // a row through the GraphQL floor. Every call carries the impersonation header,
 // so `owner = me` is stamped from the selected persona.
 
@@ -31,14 +31,19 @@ export function isFileField(field: Field): boolean {
 }
 
 /** Mint a pending object and upload the bytes. Returns the new object id. */
-export async function uploadFile(file: File, actor: string | null): Promise<string> {
-  const mint = await api("/storage/v1/object/upload/sign", actor, { method: "POST" })
+export async function uploadFile(
+  file: File,
+  actor: string | null,
+  signal?: AbortSignal,
+): Promise<string> {
+  const mint = await api("/storage/v1/object/upload/sign", actor, { method: "POST", signal })
   if (mint.status !== 200) throw new Error(envelopeError(mint, "mint"))
   const { id, url } = mint.body as { id: string; url: string }
   const put = await api(url, actor, {
     method: "PUT",
     headers: { "Content-Type": file.type || "application/octet-stream" },
     body: file,
+    signal,
   })
   if (put.status !== 204 && put.status !== 200) throw new Error(envelopeError(put, "upload"))
   return id

--- a/crates/spock-runtime/studio/src/views/fn-runner.tsx
+++ b/crates/spock-runtime/studio/src/views/fn-runner.tsx
@@ -94,7 +94,7 @@ export class FnRunner extends Component<{ name: string }, State> {
     if (!fn) return <div className="p-6 text-muted-foreground">function not found</div>
     const { actor, personas } = this.context
     const { args, result, running } = this.state
-    const actorLabel = actor
+    const actorLabel = actor !== null
       ? (personas.find((p) => p.actor === actor)?.label ?? "actor")
       : "anonymous"
 

--- a/crates/spock-runtime/studio/src/views/insert-row-sheet.tsx
+++ b/crates/spock-runtime/studio/src/views/insert-row-sheet.tsx
@@ -1,0 +1,1141 @@
+import { Component, createRef, useRef } from "react"
+import type { ChangeEvent, FormEvent, ReactNode } from "react"
+import {
+  CircleAlert,
+  Database,
+  File as FileIcon,
+  KeyRound,
+  Link2,
+  LoaderCircle,
+  LockKeyhole,
+  Pencil,
+  RotateCcw,
+  Server,
+  Upload,
+} from "lucide-react"
+
+import { api, isErrorBody } from "@/lib/api"
+import {
+  actorFromSelectValue,
+  actorSelectValue,
+  ANONYMOUS_ACTOR_SELECT_VALUE,
+} from "@/lib/actor"
+import { defaultStr, typeStr } from "@/lib/contract"
+import { GraphQLMutationError, insertRow } from "@/lib/graphql-mutations"
+import { isFileField, STORAGE_OBJECT, uploadFile } from "@/lib/storage"
+import { cn } from "@/lib/utils"
+import type { Contract, Field, Persona, Table } from "@/types"
+
+import { FileThumb } from "@/components/file-thumb"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Sheet,
+  SheetBody,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet"
+import { Textarea } from "@/components/ui/textarea"
+
+type Row = Record<string, unknown>
+
+interface Props {
+  open: boolean
+  contract: Contract
+  table: Table
+  actor: string | null
+  personas: Persona[]
+  onActorChange: (actor: string | null) => void
+  onOpenChange: (open: boolean) => void
+  onInserted: () => void
+}
+
+interface FieldDraft {
+  included: boolean
+  raw: string
+}
+
+interface ReferenceOptions {
+  loading: boolean
+  error: string | null
+  target: Table
+  key: string
+  label: string
+  rows: Row[]
+  capped: boolean
+}
+
+interface FieldUpload {
+  busy: boolean
+  objectId?: string
+  fileName?: string
+  fileSize?: number
+}
+
+interface State {
+  drafts: Record<string, FieldDraft>
+  references: Record<string, ReferenceOptions>
+  uploads: Record<string, FieldUpload>
+  fieldErrors: Record<string, string>
+  formError: string | null
+  submitting: boolean
+}
+
+const REFERENCE_LIMIT = 200
+const MAX_UPLOAD_BYTES = 25 * 1024 * 1024
+
+/**
+ * The metadata-driven insert form. It deliberately keeps "omitted" separate
+ * from a value: omission is how defaults apply, and it is how an optional
+ * field with no default becomes NULL on insert.
+ */
+export class InsertRowSheet extends Component<Props, State> {
+  state: State = initialState(this.props.table)
+  private referenceGeneration = 0
+  private uploadGeneration = 0
+  private uploadSequences = new Map<string, number>()
+  private uploadControllers = new Map<string, AbortController>()
+  private bodyRef = createRef<HTMLDivElement>()
+
+  componentDidUpdate(prev: Props) {
+    const opened = this.props.open && !prev.open
+    const tableChanged = this.props.table.name !== prev.table.name
+    if (this.props.open && (opened || tableChanged)) {
+      this.beginSession()
+      return
+    }
+    if (this.props.open && this.props.actor !== prev.actor) void this.loadReferences()
+  }
+
+  componentWillUnmount() {
+    this.referenceGeneration += 1
+    this.uploadGeneration += 1
+    this.abortAllUploads()
+  }
+
+  private beginSession = () => {
+    this.referenceGeneration += 1
+    this.uploadGeneration += 1
+    this.abortAllUploads()
+    this.setState(initialState(this.props.table), () => void this.loadReferences())
+  }
+
+  private loadReferences = async () => {
+    const generation = ++this.referenceGeneration
+    const targets = referencedTables(this.props.contract, this.props.table)
+    if (targets.length === 0) {
+      this.setState({ references: {} })
+      return
+    }
+
+    const loading = Object.fromEntries(
+      targets.map((target) => {
+        const key = target.key[0]
+        return [
+          target.name,
+          {
+            loading: true,
+            error: null,
+            target,
+            key,
+            label: referenceLabelField(target),
+            rows: [],
+            capped: false,
+          } satisfies ReferenceOptions,
+        ]
+      }),
+    )
+    this.setState({ references: loading })
+
+    const entries = await Promise.all(
+      targets.map(async (target): Promise<[string, ReferenceOptions]> => {
+        const key = target.key[0]
+        const label = referenceLabelField(target)
+        const params = new URLSearchParams({ limit: String(REFERENCE_LIMIT) })
+        if (label !== key) params.set("order", `${label}.asc`)
+        if (target.name === STORAGE_OBJECT) params.set("state", "eq.committed")
+        const res = await api(
+          `/rest/v1/${encodeURIComponent(target.name)}?${params}`,
+          this.props.actor,
+        )
+        if (res.status !== 200) {
+          const error = isErrorBody(res.body)
+            ? (res.body.error.message ?? res.body.error.code)
+            : `could not load ${target.name} rows (HTTP ${res.status})`
+          return [
+            target.name,
+            { loading: false, error, target, key, label, rows: [], capped: false },
+          ]
+        }
+        const rows = ((res.body as { rows?: Row[] }).rows ?? []).filter(
+          (row) => row[key] !== null && row[key] !== undefined,
+        )
+        return [
+          target.name,
+          {
+            loading: false,
+            error: null,
+            target,
+            key,
+            label,
+            rows,
+            capped: rows.length >= REFERENCE_LIMIT,
+          },
+        ]
+      }),
+    )
+
+    if (generation !== this.referenceGeneration) return
+    this.setState({ references: Object.fromEntries(entries) })
+  }
+
+  private setIncluded = (field: Field, included: boolean) => {
+    const clearFile = !included && isFileField(field)
+    if (clearFile) this.invalidateFieldUpload(field.name)
+    this.setState((state) => ({
+      drafts: {
+        ...state.drafts,
+        [field.name]: {
+          ...state.drafts[field.name],
+          included,
+          raw: clearFile ? "" : state.drafts[field.name].raw,
+        },
+      },
+      uploads: included ? state.uploads : omitKey(state.uploads, field.name),
+      fieldErrors: omitKey(state.fieldErrors, field.name),
+      formError: null,
+    }))
+  }
+
+  private setRaw = (field: Field, raw: string) => {
+    if (isFileField(field)) this.invalidateFieldUpload(field.name)
+    this.setState((state) => ({
+      drafts: {
+        ...state.drafts,
+        [field.name]: { included: true, raw },
+      },
+      uploads: isFileField(field) ? omitKey(state.uploads, field.name) : state.uploads,
+      fieldErrors: omitKey(state.fieldErrors, field.name),
+      formError: null,
+    }))
+  }
+
+  private changeActor = (actor: string | null) => {
+    if (actor === this.props.actor) return
+    const uploadedFields = new Set(Object.keys(this.state.uploads))
+    const actorFields = new Set(
+      this.props.table.fields
+        .filter((field) => field.default?.kind === "actor")
+        .map((field) => field.name),
+    )
+    this.uploadGeneration += 1
+    this.abortAllUploads()
+    this.setState(
+      (state) => ({
+        drafts: Object.fromEntries(
+          this.props.table.fields.map((field) => [
+            field.name,
+            uploadedFields.has(field.name) ? draftFor(field) : state.drafts[field.name],
+          ]),
+        ),
+        uploads: {},
+        fieldErrors: Object.fromEntries(
+          Object.entries(state.fieldErrors).filter(
+            ([field]) => !uploadedFields.has(field) && !actorFields.has(field),
+          ),
+        ),
+        formError:
+          uploadedFields.size > 0
+            ? "Uploaded file selections were cleared because the Actor changed."
+            : null,
+      }),
+      () => this.props.onActorChange(actor),
+    )
+  }
+
+  private uploadField = async (field: Field, file: File) => {
+    if (file.size > MAX_UPLOAD_BYTES) {
+      this.setState(
+        (state) => ({
+          fieldErrors: {
+            ...state.fieldErrors,
+            [field.name]: `Choose a file smaller than ${formatBytes(MAX_UPLOAD_BYTES)}.`,
+          },
+        }),
+        this.revealErrors,
+      )
+      return
+    }
+
+    const previousDraft = this.state.drafts[field.name] ?? draftFor(field)
+    const previousUpload = this.state.uploads[field.name]
+    const generation = this.uploadGeneration
+    const { sequence, controller } = this.beginFieldUpload(field.name)
+    this.setState((state) => ({
+      uploads: {
+        ...state.uploads,
+        [field.name]: { busy: true, fileName: file.name, fileSize: file.size },
+      },
+      fieldErrors: omitKey(state.fieldErrors, field.name),
+      formError: null,
+    }))
+
+    try {
+      const objectId = await uploadFile(file, this.props.actor, controller.signal)
+      if (!this.isCurrentUpload(field.name, generation, sequence)) return
+      this.uploadControllers.delete(field.name)
+      this.setState((state) => ({
+        drafts: {
+          ...state.drafts,
+          [field.name]: { included: true, raw: encodeReferenceValue(objectId) },
+        },
+        uploads: {
+          ...state.uploads,
+          [field.name]: {
+            busy: false,
+            objectId,
+            fileName: file.name,
+            fileSize: file.size,
+          },
+        },
+      }))
+    } catch (error) {
+      if (!this.isCurrentUpload(field.name, generation, sequence)) return
+      this.uploadControllers.delete(field.name)
+      const message = error instanceof Error ? error.message : String(error)
+      this.setState(
+        (state) => ({
+          drafts: { ...state.drafts, [field.name]: previousDraft },
+          uploads: previousUpload
+            ? { ...state.uploads, [field.name]: previousUpload }
+            : omitKey(state.uploads, field.name),
+          fieldErrors: { ...state.fieldErrors, [field.name]: message },
+        }),
+        this.revealErrors,
+      )
+    }
+  }
+
+  private beginFieldUpload = (field: string): { sequence: number; controller: AbortController } => {
+    this.uploadControllers.get(field)?.abort()
+    const controller = new AbortController()
+    this.uploadControllers.set(field, controller)
+    const sequence = (this.uploadSequences.get(field) ?? 0) + 1
+    this.uploadSequences.set(field, sequence)
+    return { sequence, controller }
+  }
+
+  private invalidateFieldUpload = (field: string) => {
+    this.uploadControllers.get(field)?.abort()
+    this.uploadControllers.delete(field)
+    this.uploadSequences.set(field, (this.uploadSequences.get(field) ?? 0) + 1)
+  }
+
+  private abortAllUploads = () => {
+    for (const controller of this.uploadControllers.values()) controller.abort()
+    this.uploadControllers.clear()
+  }
+
+  private isCurrentUpload = (field: string, generation: number, sequence: number): boolean =>
+    generation === this.uploadGeneration && sequence === this.uploadSequences.get(field)
+
+  private revealErrors = () => {
+    const body = this.bodyRef.current
+    if (!body) return
+    const invalid = body.querySelector<HTMLElement>('[aria-invalid="true"]')
+    if (invalid) {
+      invalid.scrollIntoView({ block: "center" })
+      invalid.focus()
+      return
+    }
+    body.scrollTo({ top: 0, behavior: "smooth" })
+  }
+
+  private close = () => {
+    if (this.state.submitting) return
+    this.dismiss()
+  }
+
+  private dismiss = () => {
+    this.referenceGeneration += 1
+    this.uploadGeneration += 1
+    this.abortAllUploads()
+    this.props.onOpenChange(false)
+  }
+
+  private submit = async (event: FormEvent) => {
+    event.preventDefault()
+    if (this.state.submitting || Object.values(this.state.uploads).some((upload) => upload.busy)) {
+      return
+    }
+
+    const missingActor = this.props.table.fields.filter(
+      (field) =>
+        field.default?.kind === "actor" && !field.optional && this.props.actor === null,
+    )
+    if (missingActor.length > 0) {
+      this.setState(
+        {
+          fieldErrors: Object.fromEntries(
+            missingActor.map((field) => [field.name, "Select an Actor before inserting."]),
+          ),
+          formError: "This row requires an Actor.",
+        },
+        this.revealErrors,
+      )
+      return
+    }
+
+    const parsed = buildInsertObject(this.props.table, this.state.drafts)
+    if (Object.keys(parsed.errors).length > 0) {
+      this.setState(
+        { fieldErrors: parsed.errors, formError: "Check the highlighted fields." },
+        this.revealErrors,
+      )
+      return
+    }
+
+    this.setState({ submitting: true, formError: null, fieldErrors: {} })
+    try {
+      await insertRow(this.props.table, parsed.object, this.props.actor)
+      this.props.onInserted()
+      this.setState({ submitting: false }, this.dismiss)
+    } catch (error) {
+      if (error instanceof GraphQLMutationError) {
+        const fieldErrors = Object.fromEntries(
+          error.fields.map((field) => [field, error.message]),
+        )
+        this.setState(
+          {
+            submitting: false,
+            fieldErrors,
+            formError:
+              error.code === "graphql_error" ? error.message : `${error.code} · ${error.message}`,
+          },
+          this.revealErrors,
+        )
+      } else {
+        this.setState(
+          {
+            submitting: false,
+            formError: error instanceof Error ? error.message : String(error),
+          },
+          this.revealErrors,
+        )
+      }
+    }
+  }
+
+  render() {
+    const { open, table, actor } = this.props
+    const required = table.fields.filter((field) => !field.optional && field.default == null)
+    const defaulted = table.fields.filter((field) => field.default != null)
+    const optional = table.fields.filter((field) => field.optional && field.default == null)
+    const { formError, submitting } = this.state
+    const uploading = Object.values(this.state.uploads).some((upload) => upload.busy)
+    const missingActor = table.fields.some(
+      (field) => field.default?.kind === "actor" && !field.optional && actor === null,
+    )
+
+    return (
+      <Sheet open={open} onOpenChange={(next) => (next ? this.props.onOpenChange(true) : this.close())}>
+        <SheetContent className="sm:w-[min(78vw,760px)] sm:max-w-[760px]">
+          <form
+            onSubmit={this.submit}
+            className="flex min-h-0 flex-1 flex-col"
+            aria-busy={submitting}
+          >
+            <SheetHeader className="px-6 py-5">
+              <SheetTitle className="flex items-center gap-2 text-base">
+                Add new row to <code className="text-[13px] font-semibold">{table.name}</code>
+              </SheetTitle>
+              <SheetDescription>
+                The form follows the compiled contract. Unset fields are omitted so server defaults
+                and nullable semantics stay authoritative.
+              </SheetDescription>
+            </SheetHeader>
+
+            <SheetBody ref={this.bodyRef} className="px-6 py-0">
+              {formError ? <ErrorNotice>{formError}</ErrorNotice> : null}
+
+              <fieldset disabled={submitting} className="m-0 min-w-0 border-0 p-0">
+                {required.length ? (
+                  <FieldSection
+                    title="Required fields"
+                    description="These fields have no default and must be included."
+                  >
+                    {required.map((field) => this.renderField(field, actor))}
+                  </FieldSection>
+                ) : null}
+
+                {defaulted.length ? (
+                  <FieldSection
+                    title="Defaulted fields"
+                    description="Leave these unset to let the server apply the compiled default."
+                  >
+                    {defaulted.map((field) => this.renderField(field, actor))}
+                  </FieldSection>
+                ) : null}
+
+                {optional.length ? (
+                  <FieldSection
+                    title="Optional fields"
+                    description="Omitted fields store NULL. Set one only when the row needs a value."
+                  >
+                    {optional.map((field) => this.renderField(field, actor))}
+                  </FieldSection>
+                ) : null}
+              </fieldset>
+            </SheetBody>
+
+            <SheetFooter className="px-6 py-3.5">
+              <div className="flex items-center gap-2">
+                <Button type="button" variant="outline" size="lg" onClick={this.close} disabled={submitting}>
+                  Cancel
+                </Button>
+                <Button type="submit" size="lg" disabled={submitting || uploading || missingActor}>
+                  {submitting || uploading ? <LoaderCircle className="animate-spin" /> : <Database />}
+                  {submitting ? "Inserting…" : uploading ? "Uploading…" : "Insert row"}
+                </Button>
+              </div>
+            </SheetFooter>
+          </form>
+        </SheetContent>
+      </Sheet>
+    )
+  }
+
+  private renderField(field: Field, actor: string | null): ReactNode {
+    const draft = this.state.drafts[field.name] ?? draftFor(field)
+    const error = this.state.fieldErrors[field.name]
+    const actorStamped = field.default?.kind === "actor"
+    const canOmit = field.optional || field.default != null
+    const reference = field.type.kind === "ref" ? this.state.references[field.type.table ?? ""] : undefined
+
+    return (
+      <div
+        key={field.name}
+        className="grid gap-3 border-b py-5 last:border-b-0 sm:grid-cols-[190px_minmax(0,1fr)] sm:gap-6"
+      >
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-1.5">
+            {this.props.table.key.includes(field.name) ? (
+              <KeyRound size={12} className="text-muted-foreground" />
+            ) : null}
+            <span className="font-mono text-[13px] font-semibold">{field.name}</span>
+          </div>
+          <div className="mt-1 flex flex-wrap items-center gap-1.5">
+            <span className="font-mono text-[11px] text-muted-foreground">{typeStr(field.type)}</span>
+            <FieldBadge field={field} />
+          </div>
+          {field.doc ? <p className="mt-2 text-[11px] leading-relaxed text-muted-foreground">{field.doc}</p> : null}
+        </div>
+
+        <div className="min-w-0">
+          {actorStamped ? (
+            <LockedActorField
+              field={field.name}
+              actor={actor}
+              optional={Boolean(field.optional)}
+              personas={this.props.personas}
+              onActorChange={this.changeActor}
+            />
+          ) : draft.included ? (
+            <div className="flex items-start gap-2">
+              <div className="min-w-0 flex-1">
+                <FieldControl
+                  field={field}
+                  label={field.name}
+                  value={draft.raw}
+                  reference={reference}
+                  upload={this.state.uploads[field.name]}
+                  invalid={Boolean(error)}
+                  onChange={(raw) => this.setRaw(field, raw)}
+                  onUpload={(file) => void this.uploadField(field, file)}
+                />
+              </div>
+              {canOmit ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon-lg"
+                  title={field.default ? "Use server default" : "Omit field"}
+                  onClick={() => this.setIncluded(field, false)}
+                >
+                  <RotateCcw />
+                </Button>
+              ) : null}
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => this.setIncluded(field, true)}
+              className="flex min-h-9 w-full items-center justify-between gap-3 rounded-md border bg-muted/30 px-3 py-2 text-left transition-colors hover:bg-muted/60"
+            >
+              <span className="truncate text-xs text-muted-foreground">
+                {field.default ? `Server default ${defaultStr(field.default)}` : "NULL · field omitted"}
+              </span>
+              <span className="flex shrink-0 items-center gap-1 text-[11px] font-medium text-foreground">
+                <Pencil size={12} /> Set value
+              </span>
+            </button>
+          )}
+
+          {field.default && !actorStamped ? (
+            <p className="mt-1.5 text-[11px] text-muted-foreground">Default {defaultStr(field.default)}</p>
+          ) : null}
+          {field.type.kind === "ref" ? (
+            <ReferenceHint options={reference} />
+          ) : null}
+          {field.check ? (
+            <p className="mt-1.5 text-[11px] text-muted-foreground">
+              Validated by <code>{field.check}</code>
+            </p>
+          ) : null}
+          {error ? <p className="mt-1.5 text-[11px] text-destructive">{error}</p> : null}
+        </div>
+      </div>
+    )
+  }
+}
+
+function FieldSection({
+  title,
+  description,
+  children,
+}: {
+  title: string
+  description: string
+  children: ReactNode
+}) {
+  return (
+    <section>
+      <div className="-mx-6 border-y bg-muted/30 px-6 py-4">
+        <h3 className="text-sm font-semibold">{title}</h3>
+        <p className="mt-0.5 text-xs text-muted-foreground">{description}</p>
+      </div>
+      {children}
+    </section>
+  )
+}
+
+function FieldBadge({ field }: { field: Field }) {
+  return (
+    <>
+      {!field.optional && field.default == null ? <Badge variant="outline">required</Badge> : null}
+      {field.optional ? <Badge variant="outline">nullable</Badge> : null}
+      {field.default?.kind === "actor" ? (
+        <Badge variant="outline">server</Badge>
+      ) : field.default ? (
+        <Badge variant="outline">default</Badge>
+      ) : null}
+    </>
+  )
+}
+
+function LockedActorField({
+  field,
+  actor,
+  optional,
+  personas,
+  onActorChange,
+}: {
+  field: string
+  actor: string | null
+  optional: boolean
+  personas: Persona[]
+  onActorChange: (actor: string | null) => void
+}) {
+  return (
+    <div>
+      <Select
+        value={actor === null && !optional ? null : actorSelectValue(actor)}
+        onValueChange={(value) => onActorChange(actorFromSelectValue(value))}
+      >
+        <SelectTrigger
+          className="h-9 w-full bg-muted/40 px-3"
+          aria-label={`${field} Actor`}
+          aria-invalid={!optional && actor === null}
+        >
+          <LockKeyhole size={14} className="text-muted-foreground" />
+          <SelectValue placeholder="Select an Actor">
+            {(value: unknown) => {
+              const selectedActor = actorFromSelectValue(value)
+              return selectedActor === null
+                ? optional
+                  ? "Anonymous · server will store NULL"
+                  : "Select an Actor before inserting"
+                : `Actor · ${personas.find((persona) => persona.actor === selectedActor)?.label ?? selectedActor}`
+            }}
+          </SelectValue>
+        </SelectTrigger>
+        <SelectContent alignItemWithTrigger={false} className="min-w-[300px]">
+          {optional ? (
+            <SelectItem value={ANONYMOUS_ACTOR_SELECT_VALUE}>anonymous · store NULL</SelectItem>
+          ) : null}
+          {personas.map((persona) => (
+            <SelectItem key={persona.actor} value={actorSelectValue(persona.actor)}>
+              <span>{persona.label}</span>
+              <span className="max-w-52 truncate font-mono text-[10px] text-muted-foreground">
+                {persona.actor}
+              </span>
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <p className="mt-1.5 flex items-center gap-1 text-[11px] text-muted-foreground">
+        <Server size={11} /> <code>= me</code> uses Studio's Actor request context; it is never sent as a field value.
+      </p>
+    </div>
+  )
+}
+
+function FieldControl({
+  field,
+  label,
+  value,
+  reference,
+  upload,
+  invalid,
+  onChange,
+  onUpload,
+}: {
+  field: Field
+  label: string
+  value: string
+  reference?: ReferenceOptions
+  upload?: FieldUpload
+  invalid: boolean
+  onChange: (value: string) => void
+  onUpload: (file: File) => void
+}) {
+  if (!isKnownFieldKind(field.type.kind)) {
+    return (
+      <div
+        className="flex min-h-9 items-center rounded-md border border-destructive/30 bg-destructive/5 px-3 text-xs text-destructive"
+        role="alert"
+      >
+        Unsupported contract type <code>{field.type.kind}</code>
+      </div>
+    )
+  }
+
+  if (field.type.kind === "ref") {
+    if (isFileField(field)) {
+      return (
+        <StorageObjectControl
+          value={value}
+          reference={reference}
+          upload={upload}
+          invalid={invalid}
+          label={label}
+          onChange={onChange}
+          onUpload={onUpload}
+        />
+      )
+    }
+    return (
+      <ReferenceSelect
+        value={value}
+        reference={reference}
+        invalid={invalid}
+        label={label}
+        placeholder={`Select ${field.type.table ?? "row"}`}
+        onChange={onChange}
+      />
+    )
+  }
+
+  if (field.type.kind === "set") {
+    return (
+      <Select value={value || null} onValueChange={(next) => onChange(String(next))}>
+        <SelectTrigger className="h-9 w-full px-3" aria-label={label} aria-invalid={invalid}>
+          <SelectValue placeholder="Select a value" />
+        </SelectTrigger>
+        <SelectContent>
+          {(field.type.values ?? []).map((option) => (
+            <SelectItem key={option} value={option}>
+              <span className="font-mono">{option}</span>
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    )
+  }
+
+  if (field.type.kind === "bool") {
+    return (
+      <Select value={value || null} onValueChange={(next) => onChange(String(next))}>
+        <SelectTrigger className="h-9 w-full px-3" aria-label={label} aria-invalid={invalid}>
+          <SelectValue placeholder="Select true or false" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="true">TRUE</SelectItem>
+          <SelectItem value="false">FALSE</SelectItem>
+        </SelectContent>
+      </Select>
+    )
+  }
+
+  if (field.type.kind === "text") {
+    return (
+      <Textarea
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder="Enter text"
+        aria-label={label}
+        aria-invalid={invalid}
+      />
+    )
+  }
+
+  const type = field.type.kind === "int" || field.type.kind === "float" ? "number" : field.type.kind === "timestamp" ? "datetime-local" : "text"
+  return (
+    <Input
+      type={type}
+      step={field.type.kind === "int" ? 1 : field.type.kind === "float" ? "any" : undefined}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      placeholder={field.type.kind === "uuid" ? "00000000-0000-0000-0000-000000000000" : "Enter value"}
+      aria-label={label}
+      aria-invalid={invalid}
+      className="h-9 px-3"
+    />
+  )
+}
+
+function StorageObjectControl({
+  value,
+  reference,
+  upload,
+  invalid,
+  label,
+  onChange,
+  onUpload,
+}: {
+  value: string
+  reference?: ReferenceOptions
+  upload?: FieldUpload
+  invalid: boolean
+  label: string
+  onChange: (value: string) => void
+  onUpload: (file: File) => void
+}) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const uploaded = upload?.objectId
+
+  const pick = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    event.target.value = ""
+    if (file) onUpload(file)
+  }
+
+  return (
+    <div className="space-y-3">
+      <input
+        ref={inputRef}
+        type="file"
+        hidden
+        disabled={upload?.busy}
+        aria-label={`Upload ${label}`}
+        onChange={pick}
+      />
+      <div
+        className={cn(
+          "flex min-h-16 items-center gap-3 rounded-md border bg-muted/20 p-3",
+          invalid && "border-destructive/50",
+        )}
+      >
+        {uploaded ? (
+          <FileThumb id={uploaded} size={38} className="shrink-0" />
+        ) : (
+          <span className="flex size-9 shrink-0 items-center justify-center rounded-md border bg-background text-muted-foreground">
+            {upload?.busy ? <LoaderCircle size={16} className="animate-spin" /> : <FileIcon size={16} />}
+          </span>
+        )}
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-xs font-medium">
+            {upload?.fileName ?? "Upload a new file"}
+          </p>
+          <p className="mt-0.5 truncate text-[11px] text-muted-foreground">
+            {upload?.busy
+              ? "Uploading through the storage gate…"
+              : uploaded
+                ? `${upload.fileSize === undefined ? "Uploaded" : formatBytes(upload.fileSize)} · attached when this row is inserted`
+                : `Any file up to ${formatBytes(MAX_UPLOAD_BYTES)}`}
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="lg"
+          disabled={upload?.busy}
+          aria-invalid={invalid}
+          onClick={() => inputRef.current?.click()}
+        >
+          {upload?.busy ? <LoaderCircle className="animate-spin" /> : <Upload />}
+          {upload?.busy ? "Uploading…" : uploaded ? "Replace" : "Upload file"}
+        </Button>
+      </div>
+
+      <div className="flex items-center gap-2 text-[10px] uppercase tracking-wide text-muted-foreground">
+        <span className="h-px flex-1 bg-border" />
+        or choose an existing object
+        <span className="h-px flex-1 bg-border" />
+      </div>
+      <ReferenceSelect
+        value={uploaded ? "" : value}
+        reference={reference}
+        invalid={invalid}
+        label={`${label}: existing storage object`}
+        placeholder="Select an uploaded file"
+        onChange={onChange}
+      />
+    </div>
+  )
+}
+
+function ReferenceSelect({
+  value,
+  reference,
+  invalid,
+  label,
+  placeholder,
+  onChange,
+}: {
+  value: string
+  reference?: ReferenceOptions
+  invalid: boolean
+  label: string
+  placeholder: string
+  onChange: (value: string) => void
+}) {
+  const emptyLabel = reference?.loading
+    ? "Loading referenced rows…"
+    : reference?.error
+      ? "Referenced rows unavailable"
+      : placeholder
+
+  return (
+    <Select value={value || null} onValueChange={(next) => onChange(String(next))}>
+      <SelectTrigger
+        className="h-9 w-full px-3"
+        aria-label={label}
+        aria-invalid={invalid}
+      >
+        <SelectValue placeholder={emptyLabel}>
+          {(selected: unknown) =>
+            selected == null || selected === ""
+              ? emptyLabel
+              : selectedReferenceLabel(String(selected), reference)
+          }
+        </SelectValue>
+      </SelectTrigger>
+      <SelectContent alignItemWithTrigger={false} className="min-w-[340px] max-w-[560px]">
+        {(reference?.rows ?? []).map((row) => {
+          const token = encodeReferenceValue(row[reference!.key])
+          return (
+            <SelectItem key={token} value={token}>
+              <span className="min-w-0 flex-1 truncate">{referenceLabel(row, reference!)}</span>
+              {reference!.label !== reference!.key ? (
+                <span className="max-w-48 truncate font-mono text-[10px] text-muted-foreground">
+                  {String(row[reference!.key])}
+                </span>
+              ) : null}
+            </SelectItem>
+          )
+        })}
+      </SelectContent>
+    </Select>
+  )
+}
+
+function ReferenceHint({ options }: { options?: ReferenceOptions }) {
+  if (!options) return null
+  return (
+    <p
+      className={cn(
+        "mt-1.5 flex items-center gap-1 text-[11px] text-muted-foreground",
+        options.error && "text-destructive",
+      )}
+    >
+      <Link2 size={11} />
+      {options.error ? (
+        options.error
+      ) : options.loading ? (
+        `Loading ${options.target.name} rows…`
+      ) : (
+        <>
+          References <code>{options.target.name}.{options.key}</code>
+          {options.label !== options.key ? <> · labeled by <code>{options.label}</code></> : null}
+          {options.capped ? ` · first ${REFERENCE_LIMIT} rows` : ""}
+        </>
+      )}
+    </p>
+  )
+}
+
+function ErrorNotice({ children }: { children: ReactNode }) {
+  return (
+    <div
+      role="alert"
+      className="mt-4 flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-xs text-destructive"
+    >
+      <CircleAlert size={14} className="mt-0.5 shrink-0" />
+      <span>{children}</span>
+    </div>
+  )
+}
+
+function initialState(table: Table): State {
+  return {
+    drafts: Object.fromEntries(table.fields.map((field) => [field.name, draftFor(field)])),
+    references: {},
+    uploads: {},
+    fieldErrors: {},
+    formError: null,
+    submitting: false,
+  }
+}
+
+function draftFor(field: Field): FieldDraft {
+  return {
+    included: !field.optional && field.default == null,
+    raw: defaultRaw(field),
+  }
+}
+
+function defaultRaw(field: Field): string {
+  const value = field.default?.value
+  return value === undefined || value === null ? "" : String(value)
+}
+
+function referencedTables(contract: Contract, table: Table): Table[] {
+  const names = new Set(
+    table.fields
+      .filter((field) => field.type.kind === "ref" && field.default?.kind !== "actor")
+      .map((field) => (field.type as { table?: string }).table)
+      .filter((name): name is string => Boolean(name)),
+  )
+  return [...names]
+    .map((name) => contract.tables.find((candidate) => candidate.name === name))
+    .filter((target): target is Table => Boolean(target?.key[0]))
+}
+
+/** Generic contracts do not yet declare a display column for references. */
+function referenceLabelField(table: Table): string {
+  return (
+    table.fields.find(
+      (field) => field.name !== table.key[0] && field.type.kind === "text" && field.unique,
+    )?.name ??
+    table.fields.find((field) => field.name !== table.key[0] && field.type.kind === "text")?.name ??
+    table.key[0]
+  )
+}
+
+function referenceLabel(row: Row, options: ReferenceOptions): string {
+  const label = row[options.label]
+  return label === null || label === undefined || label === "" ? String(row[options.key]) : String(label)
+}
+
+function selectedReferenceLabel(token: string, options?: ReferenceOptions): string {
+  const row = options?.rows.find((candidate) => encodeReferenceValue(candidate[options.key]) === token)
+  if (row && options) return referenceLabel(row, options)
+  try {
+    return String(JSON.parse(token) as unknown)
+  } catch {
+    return token
+  }
+}
+
+function encodeReferenceValue(value: unknown): string {
+  return JSON.stringify(value)
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KiB`
+  return `${Math.round((bytes / (1024 * 1024)) * 10) / 10} MiB`
+}
+
+function buildInsertObject(
+  table: Table,
+  drafts: Record<string, FieldDraft>,
+): { object: Record<string, unknown>; errors: Record<string, string> } {
+  const object: Record<string, unknown> = {}
+  const errors: Record<string, string> = {}
+
+  for (const field of table.fields) {
+    if (field.default?.kind === "actor") continue
+    const draft = drafts[field.name] ?? draftFor(field)
+    if (!draft.included) continue
+    try {
+      object[field.name] = parseFieldValue(field, draft.raw)
+    } catch (error) {
+      errors[field.name] = error instanceof Error ? error.message : String(error)
+    }
+  }
+  return { object, errors }
+}
+
+function parseFieldValue(field: Field, raw: string): unknown {
+  switch (field.type.kind) {
+    case "int": {
+      if (raw.trim() === "") throw new Error("Enter an integer.")
+      const value = Number(raw)
+      if (!Number.isSafeInteger(value)) throw new Error("Enter a valid integer.")
+      return value
+    }
+    case "float": {
+      if (raw.trim() === "") throw new Error("Enter a number.")
+      const value = Number(raw)
+      if (!Number.isFinite(value)) throw new Error("Enter a valid number.")
+      return value
+    }
+    case "bool":
+      if (raw !== "true" && raw !== "false") throw new Error("Select true or false.")
+      return raw === "true"
+    case "timestamp": {
+      if (raw.trim() === "") throw new Error("Choose a date and time.")
+      const value = new Date(raw)
+      if (Number.isNaN(value.getTime())) throw new Error("Choose a valid date and time.")
+      return value.toISOString()
+    }
+    case "ref":
+      if (!raw)
+        throw new Error(
+          `Select a ${(field.type as { table?: string }).table ?? "referenced row"}.`,
+        )
+      return JSON.parse(raw) as unknown
+    case "set":
+      if (!(field.type.values ?? []).includes(raw)) throw new Error("Select an allowed value.")
+      return raw
+    case "uuid":
+      if (raw.trim() === "") throw new Error("Enter a UUID.")
+      return raw.trim()
+    case "text":
+      return raw
+    default:
+      throw new Error(`Studio does not support the contract type ${field.type.kind}.`)
+  }
+}
+
+function isKnownFieldKind(kind: string): boolean {
+  return ["text", "int", "float", "bool", "timestamp", "uuid", "ref", "set"].includes(kind)
+}
+
+function omitKey<T>(record: Record<string, T>, key: string): Record<string, T> {
+  const { [key]: _discarded, ...rest } = record
+  return rest
+}

--- a/crates/spock-runtime/studio/src/views/storage-view.tsx
+++ b/crates/spock-runtime/studio/src/views/storage-view.tsx
@@ -1,5 +1,5 @@
-// The Storage page (RFD 0018) — a Supabase-Storage-style browser over the
-// `storage_object` table: every uploaded file as a card, with an upload button
+// The Storage page (RFD 0018) browses the `storage_object` table: every uploaded
+// file is a card, with an upload button
 // that drives the same signed-URL gate any client uses. Standalone uploads here
 // are unattached, so the orphan sweep reclaims them unless a row references
 // them — the note says so.

--- a/crates/spock-runtime/studio/src/views/table-view.tsx
+++ b/crates/spock-runtime/studio/src/views/table-view.tsx
@@ -44,6 +44,7 @@ import {
 import { Doc } from "@/components/doc"
 import { ErrCodes } from "@/components/err-codes"
 import { FileThumb } from "@/components/file-thumb"
+import { InsertRowSheet } from "@/views/insert-row-sheet"
 
 type Row = Record<string, unknown>
 type Mode = "data" | "schema"
@@ -57,6 +58,7 @@ interface State {
   sorts: SortRule[]
   loading: boolean
   err: string | null
+  insertOpen: boolean
 }
 
 // The filter/sort popovers are stateless — every mutation flows back through
@@ -98,10 +100,12 @@ export class TableView extends Component<{ name: string }, State> {
     sorts: [],
     loading: false,
     err: null,
+    insertOpen: false,
   }
   private lastActor: string | null = null
   private lastReload = -1
   private lastQuery: string | null = null
+  private loadGeneration = 0
 
   private table(): Table | undefined {
     return this.context.contract.tables.find((t) => t.name === this.props.name)
@@ -135,9 +139,14 @@ export class TableView extends Component<{ name: string }, State> {
     }
   }
 
+  componentWillUnmount() {
+    this.loadGeneration += 1
+  }
+
   private load = async () => {
     const table = this.table()
     if (!table) return
+    const generation = ++this.loadGeneration
     this.setState({ loading: true, err: null })
     const { filters, sorts, limit, offset } = this.state
     const qs = buildQuery(filters, sorts, limit, offset)
@@ -145,7 +154,7 @@ export class TableView extends Component<{ name: string }, State> {
     const res = await api(`/rest/v1/${encodeURIComponent(table.name)}?${qs}`, this.context.actor)
     // a newer load() may have started (rewriting lastQuery) while this request
     // was in flight — drop the now-stale response so it can't clobber fresh rows
-    if (qs !== this.lastQuery) return
+    if (generation !== this.loadGeneration || qs !== this.lastQuery) return
     if (res.status !== 200) {
       // surface the floor's refusal (unknown_field / type_mismatch / bad_request)
       const msg = isErrorBody(res.body)
@@ -243,7 +252,7 @@ export class TableView extends Component<{ name: string }, State> {
       left: (
         <span>
           rows <b className="text-foreground">{start}</b>–<b className="text-foreground">{end}</b>
-          {rows.length >= limit ? " (more)" : ""} · read-only
+          {rows.length >= limit ? " (more)" : ""} · grid read-only
         </span>
       ),
       right:
@@ -292,7 +301,7 @@ export class TableView extends Component<{ name: string }, State> {
   render() {
     const table = this.table()
     if (!table) return <div className="p-6 text-muted-foreground">table not found</div>
-    const { mode, rows, limit, offset, filters, sorts, loading, err } = this.state
+    const { mode, rows, limit, offset, filters, sorts, loading, err, insertOpen } = this.state
     const meCols = table.fields.filter((f) => f.default?.kind === "actor").map((f) => f.name)
 
     const filterCtl: FilterCtl = {
@@ -344,6 +353,11 @@ export class TableView extends Component<{ name: string }, State> {
               <FilterButton table={table} filters={filters} ctl={filterCtl} />
               <SortButton table={table} sorts={sorts} ctl={sortCtl} />
               <div className="flex-1" />
+              {!table.builtin ? (
+                <Button size="sm" onClick={() => this.setState({ insertOpen: true })}>
+                  <Plus size={14} /> Add row
+                </Button>
+              ) : null}
               <Pager
                 offset={offset}
                 count={rows.length}
@@ -371,9 +385,9 @@ export class TableView extends Component<{ name: string }, State> {
               Table reads aren't affected by the <b className="text-foreground">Actor</b>{" "}
               selector — impersonation changes function results and <code>= me</code> stamps,
               not which rows you can read. <b className="text-foreground">Filter</b> and{" "}
-              <b className="text-foreground">Sort</b> run on the server. File columns upload
-              through storage; inline <b className="text-foreground">editing</b> isn't
-              available yet.
+              <b className="text-foreground">Sort</b> run on the server. <b className="text-foreground">Add row</b>{" "}
+              follows the compiled contract; file columns update through storage. Other inline{" "}
+              <b className="text-foreground">editing</b> isn't available yet.
             </Note>
             <div className="flex-1 min-h-0 border rounded-md overflow-hidden mt-3">
               {err ? (
@@ -396,6 +410,19 @@ export class TableView extends Component<{ name: string }, State> {
         ) : (
           <SchemaMode table={table} meCols={meCols} />
         )}
+        <InsertRowSheet
+          open={insertOpen}
+          contract={this.context.contract}
+          table={table}
+          actor={this.context.actor}
+          personas={this.context.personas}
+          onActorChange={this.context.setActor}
+          onOpenChange={(open) => this.setState({ insertOpen: open })}
+          onInserted={() => {
+            void this.load()
+            if (table.anchor) void this.context.refreshPersonas()
+          }}
+        />
       </div>
     )
   }
@@ -430,7 +457,7 @@ function Tab({
   )
 }
 
-// --- filter popover (Supabase-style) ---------------------------------------
+// --- filter popover ---------------------------------------------------------
 // A funnel button whose badge counts the *applied* filters, opening a panel of
 // [column][operator][value][remove] rows. Each row lowers to one PostgREST
 // clause on the floor (crates/spock-runtime/src/filter.rs).
@@ -593,8 +620,8 @@ function ValueSelect({
 }
 
 // --- sort popover ----------------------------------------------------------
-// Mirrors Supabase's Sort: applied terms as [column][asc/desc][remove] rows,
-// plus a column picker to append one. The floor forces a primary-key tiebreak
+// Applied terms render as [column][asc/desc][remove] rows, with a column picker
+// to append one. The floor forces a primary-key tiebreak
 // in the last term's direction, so the visible order is always a total order.
 function SortButton({ table, sorts, ctl }: { table: Table; sorts: SortRule[]; ctl: SortCtl }) {
   const used = new Set(sorts.map((s) => s.column))

--- a/docs/rfd/0013-value-constraints.md
+++ b/docs/rfd/0013-value-constraints.md
@@ -284,6 +284,14 @@ check now compensates). The message names the validator and the contract's
 `Field.check` lets a client find it; distinguishing *which conjunct* failed is
 what refusals are still for.
 
+**Studio consequence (S3).** Name-only validator metadata is enough to route
+and explain an error, but not enough for a generated form to derive honest
+`min`, `max`, `pattern`, or compound-rule controls. Studio must keep the server
+authoritative and may only add those controls if a future additive contract
+explicitly carries structured hints; parsing validator SQL would violate this
+RFD's opacity boundary. Tracked in
+`crates/spock-runtime/studio/FEEDBACK.md` S3.
+
 ## 6. What this deliberately does not do
 
 - **Curated named formats (`email`, `url`, `slug`).** They stay out until a

--- a/docs/rfd/0015-studio.md
+++ b/docs/rfd/0015-studio.md
@@ -269,6 +269,13 @@ GET /~personas
 Resolves "pick a known identity, don't type a raw UUID" with no persona-name
 mini-grammar — the picker *is* the anchor table's seed rows.
 
+**Write-form feedback (S1).** This endpoint defines a label for actors, but the
+compiled contract defines no equivalent presentation field for generic
+references. Studio currently uses unique-text → text → key as a heuristic.
+Making a generic label authoritative requires an additive contract decision;
+the finding and close condition live in
+`crates/spock-runtime/studio/FEEDBACK.md` S1.
+
 ### 6.2 `GET /~whoami` — the echo
 
 The dev-tier mirror of GoTrue's `GET /user`; a debugging primitive that **never
@@ -422,6 +429,10 @@ heuristic, never as contract truth. The authoritative signals are the anchor, th
 7. **Role / policy / view** ledger columns — arrive with v1 governance.
 8. **Consuming `spock gen types`** inside Studio — allowed, not required for MVP;
    the SPA can hand-type the few shapes it needs first.
+9. **Reference-picker search and paging** — the filter/query layer now supplies
+   `offset`, filtering, and ordering, so basic remote lookup is Studio-owned
+   implementation work (S2). Exact counts and safe keyset cursors remain the
+   protocol findings already recorded in `examples/filter-lab/FEEDBACK.md`.
 
 ## 12. Open questions (for ratification)
 

--- a/docs/rfd/0018-storage.md
+++ b/docs/rfd/0018-storage.md
@@ -142,6 +142,15 @@ No `bucket`, `path`, `version`, or `metadata jsonb` — buckets and versioning a
 out of v0, objects are id-addressed, and columns are explicit (no jsonb type in
 v0).
 
+**Implementation gap (Studio feedback S6).** The schema above promises the
+original filename, but the current signed-upload implementation does not carry
+one through mint or persist one from PUT; it records only content type, size,
+and checksum. Studio therefore knows a browser upload's `File.name` only for
+the current form session. The close must define whether the untrusted filename
+travels in the mint body or a signature-bound PUT header, persist it to
+`storage_object.name`, and add a storage test. Tracked in
+`crates/spock-runtime/studio/FEEDBACK.md` S6.
+
 ## 3. The protocol (`/storage/v1`, active only when `storage_object` exists)
 
 | Route | Supabase analogue | Behavior |

--- a/docs/spec/graphql.md
+++ b/docs/spec/graphql.md
@@ -71,6 +71,12 @@ The mirroring rule has three clauses:
   `<table>_order_by` (Tier 2).
 - **Scalars** are lowercase, Hasura-style: `uuid`, `timestamp` (plus the
   GraphQL builtins `String`, `Int`, `Boolean`, `Float`, `ID`).
+- **Open integer conformance gap (Studio feedback S5).** Spock `int` is signed
+  64-bit, while GraphQL's built-in `Int` is signed 32-bit and JavaScript
+  numbers are exactly integral only through `2^53 - 1`. The current `Int`
+  mapping is therefore not a truthful full-width wire. A custom scalar/string
+  encoding or a deliberately narrower language type requires a follow-up
+  decision; see `crates/spock-runtime/studio/FEEDBACK.md` S5.
 - **Field names** are the contract's, verbatim.
 - **Reserved table names** (collide with roots or scalars): `query`,
   `mutation`, `subscription`, `uuid`, `timestamp`. A table with one of
@@ -117,7 +123,9 @@ Input types:
   `<t>_<field>_required` error with its code in `extensions` — the error
   surface stays uniform instead of splitting between GraphQL validation
   and the contract. Defaults apply on omission; on insert, `null` is
-  absence (spec v0 §5.1).
+  absence (spec v0 §5.1). Consequently, an optional field with a default cannot
+  receive SQL `NULL` in the same insert: both omission and `null` apply the
+  default. This deliberate v0 limitation is tracked as Studio feedback S4.
 - `<t>_set_input` — every **non-key** field, all nullable, with update
   semantics: **absent = keep, explicit `null` = clear** (or the derived
   `required` error on a required field). Key fields never appear in


### PR DESCRIPTION
## Summary

- add a metadata-driven right-sheet form for inserting table rows
- select foreign-key targets and actor identities from contract-backed options
- support direct storage uploads as well as existing committed object selection
- refresh personas after inserting authentication rows
- document the current write contract and explicitly deferred metadata limitations

## Why

Studio was read-only even though the runtime already exposes the GraphQL insert and storage upload contracts. This makes those existing capabilities usable while respecting field types, requiredness, nullability, defaults, references, actor fields, and storage constraints.

## Validation

- `corepack pnpm exec tsc -b --force --pretty false`
- `corepack pnpm lint` (pre-existing lifecycle/fast-refresh warnings only)
- `corepack pnpm build`
- `cargo test -p spock-runtime --test graphql --test http --test storage` (21 passed)
- manual insert, foreign-key, actor, validation-focus, persona-refresh, and direct-upload flows
