### PR TITLE
chore: tighten VS Code extension package

### DIFF
--- a/editors/vscode/LICENSE
+++ b/editors/vscode/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Grida
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -4,6 +4,11 @@
   "description": "Minimal local VS Code loader for the canonical Spock v0 TextMate grammar.",
   "version": "0.0.1",
   "license": "MIT",
+  "files": [
+    "LICENSE",
+    "language-configuration.json",
+    "syntaxes/**"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/gridaco/spock"


### PR DESCRIPTION
## Summary

- add the repository MIT license to the local Spock VS Code extension package
- declare the extension's shipped files explicitly
- keep development-only `.vscode` launch configuration and compiler corpus out of the installed VSIX

## Why

The canonical TextMate grammar and compiler parity tests were already complete, but `vsce package` emitted packaging warnings and included development fixtures in the distributable archive.

This is limited to `editors/vscode` and does not change the Spock language, compiler, CLI, or runtime.

## Validation

- `cargo test --locked -p spock-lang` — 124 tests passed
- `cargo run --locked -q -p spock-cli -- check editors/vscode/test/corpus.spock` — accepted
- `npx --yes @vscode/vsce package --out /tmp/spock-textmate-loader-clean.vsix` — packaged without warnings
- verified the VSIX contains only the manifest, README, license, language configuration, and TextMate grammar
- `git diff --check`
