### PR TITLE
Prototype nominal product-error declarations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2613,6 +2613,7 @@ dependencies = [
 name = "uhura-editor-model"
 version = "0.0.0"
 dependencies = [
+ "serde",
  "serde_json",
  "uhura-base",
  "uhura-check",

--- a/README.md
+++ b/README.md
@@ -104,12 +104,14 @@ provider once, then one command checks and serves the authority and client:
 ```sh
 corepack pnpm@10.11.0 -C uhura/web install --frozen-lockfile
 corepack pnpm@10.11.0 -C uhura/web build:provider
-npx --yes spock@0.5.0 start uhura/examples/instagram
+cargo run --locked -p spock-cli -- start uhura/examples/instagram
 ```
 
-This is also the distribution smoke: the second command runs the published npm
-CLI, not `target/debug/spock`. The same project remains independently checkable
-as a Spock backend and an Uhura client.
+On this experimental RFD 0024 branch, the final command uses the source
+toolchain because the backend fixture contains proposed `error` declarations.
+Supported `main` keeps this as a distribution smoke with the published npm
+CLI. The same project remains independently checkable as a Spock backend and
+an Uhura client.
 
 `spock dev` deliberately has asymmetric reload semantics today. Valid Uhura
 client saves publish live. Invalid saves retain the last good Play generation
@@ -385,9 +387,10 @@ linked, queryable, governable entities rather than detached blobs. Channels —
 email and other outbound systems — are planned to join them as explicit
 contracts, though that part of the design is not settled.
 
-Four more concepts are committed from day one, even though their syntax is
-not: `error` — failure outcomes are part of a function's contract, derived
-from the schema's own constraints rather than guessed; `role` and `policy` —
+Four more concepts are committed from day one, even though much of their syntax
+is not: `error` — failure outcomes are part of a function's contract; schema
+failures are derived from constraints, while draft RFD 0024 proposes an
+explicit home for authored product failures; `role` and `policy` —
 the actor taxonomy, and named, testable blocks of authorization logic that are
 deliberately richer than SQL predicates; and `seed` — the world is populated
 through the contract itself, so every prototype runs against believable state.
@@ -398,6 +401,11 @@ SQL's own ceiling. Where a field traces back to a base column, even renamed or
 nested, writes flow through it; computed fields are read-only by construction.
 Writability is provenance, derived per field
 (`docs/rfd/0003-write-through-views.md`).
+
+> **RFD 0024 branch prototype — experimental, unstable, and non-normative.**
+> The top-level `error` declaration below is proposed in draft RFD 0024, not
+> supported v0 syntax. This branch is evidence only, is not for merge, and asks
+> for no language adoption.
 
 ```spock
 // a value rule is an ordinary read fn; a `check` inline-expands it into a
@@ -420,10 +428,13 @@ view post_preview from post {
     published: .published
 }
 
-// deliberate mutation — shipped v0 syntax: the signature is the
-// contract (`mut` declares the polarity, `already_published` is a
-// refusal this fn mints), the body is a sequence of SQL escapes (it
-// may replace the body, never the contract)
+/// The post has already crossed the publication boundary.
+error already_published
+
+// deliberate mutation — `mut fn`, `!`, and the SQL body are shipped v0;
+// RFD 0024 proposes resolving `already_published` through the declaration
+// above. The signature remains the contract; an escape may replace the body,
+// never the contract.
 mut fn publish_post(post: post) -> post ! already_published | not_found {
     unchecked sql("""
       SELECT spock_refuse('already_published')

--- a/crates/spock-lang/src/ast.rs
+++ b/crates/spock-lang/src/ast.rs
@@ -15,8 +15,18 @@ pub struct File {
     pub doc: Option<String>,
     pub tables: Vec<TableDecl>,
     pub records: Vec<RecordDecl>,
+    pub errors: Vec<ErrorDecl>,
     pub fns: Vec<FnDecl>,
     pub seeds: Vec<SeedBlock>,
+}
+
+/// `error name` — a contract-global authored product-error symbol.
+#[derive(Clone, Debug)]
+pub struct ErrorDecl {
+    /// `///` outer doc comments preceding the declaration.
+    pub doc: Option<String>,
+    pub name: Ident,
+    pub span: Span,
 }
 
 #[derive(Clone, Debug)]
@@ -172,7 +182,7 @@ pub struct FnDecl {
     pub mutates: bool,
     pub params: Vec<ParamDecl>,
     pub ret: RetDecl,
-    /// Declared error codes (the `! a | b` clause), possibly empty.
+    /// Error codes named by the `! a | b` clause, possibly empty.
     pub errors: Vec<Ident>,
     /// The escape body: one or more `unchecked sql(...)` statements in
     /// execution order; the last produces the return value (§7.4).

--- a/crates/spock-lang/src/check.rs
+++ b/crates/spock-lang/src/check.rs
@@ -221,13 +221,19 @@ impl Checker {
         // are the duplicate-name error (E001), not a second collision.
         self.check_derived_uniqueness(&tables, &spans);
 
+        // Authored product-error vocabulary. This runs only after derived
+        // errors exist so declarations can be checked against every runtime
+        // routing code, while remaining order-independent in source.
+        let errors = self.check_error_defs(file, &tables);
+
         // Seed (§4 E020–E028), against the lowered tables.
         let seed = self.check_seed(file, &tables);
 
-        // Phase C: records and fns (§4 E030–E039). Runs after derived
-        // errors are attached — the `!` clause validates against them.
+        // Phase C: records and fns (§4 E030–E039, E052). Runs after derived
+        // and authored errors are attached — the `!` clause validates against
+        // the complete contract-global vocabulary.
         let records = self.check_records(file, &table_names);
-        let fns = self.check_fns(file, &tables, &records, &table_names);
+        let fns = self.check_fns(file, &tables, &records, &table_names, &errors);
 
         // Phase D: validator-fn `check` references (RFD 0013 E041/E042).
         // Runs after fns exist and ref-key types are resolved (L-M).
@@ -236,11 +242,77 @@ impl Checker {
         Contract {
             spock: "v0".into(),
             doc: file.doc.clone(),
+            errors,
             tables,
             records,
             fns,
             seed,
         }
+    }
+
+    /// Lower the explicitly declared product-error vocabulary. Declarations
+    /// own names only: a fn must still list a product error in its `!` clause
+    /// before the runtime may route `spock_refuse()` to it.
+    fn check_error_defs(&mut self, file: &ast::File, tables: &[Table]) -> Vec<ErrorDef> {
+        let derived: HashMap<&str, (&str, &DerivedError)> = tables
+            .iter()
+            .flat_map(|table| {
+                table
+                    .errors
+                    .iter()
+                    .map(|error| (error.code.as_str(), (table.name.as_str(), error)))
+            })
+            .collect();
+        let mut seen: HashSet<&str> = HashSet::new();
+        let mut errors = Vec::new();
+
+        for decl in &file.errors {
+            let code = decl.name.name.as_str();
+            if !seen.insert(code) {
+                self.error(
+                    "E051",
+                    format!("duplicate error declaration `{code}`"),
+                    decl.name.span,
+                );
+                continue;
+            }
+
+            if RESERVED_CODES.contains(&code) {
+                self.error(
+                    "E053",
+                    format!(
+                        "error declaration `{code}` collides with protocol-reserved code `{code}`; choose a distinct product-error name"
+                    ),
+                    decl.name.span,
+                );
+                continue;
+            }
+            if let Some((table, error)) = derived.get(code) {
+                let owner = if error.fields.is_empty() {
+                    format!("table `{table}`")
+                } else {
+                    format!(
+                        "table `{table}` over field(s) `{}`",
+                        error.fields.join("`, `")
+                    )
+                };
+                self.error(
+                    "E053",
+                    format!(
+                        "error declaration `{code}` collides with derived code `{code}` owned by {owner}; choose a distinct product-error name"
+                    ),
+                    decl.name.span,
+                );
+                continue;
+            }
+
+            errors.push(ErrorDef {
+                code: decl.name.name.clone(),
+                doc: decl.doc.clone(),
+            });
+        }
+
+        errors
     }
 
     /// Records (§3): named wire shapes. Scalar fields only; table-only
@@ -407,13 +479,22 @@ impl Checker {
         tables: &[Table],
         records: &[Record],
         table_names: &HashSet<&str>,
+        product_errors: &[ErrorDef],
     ) -> Vec<FnDef> {
-        // the `!` clause vocabulary: every derived code + the reserved five
+        // The `!` clause vocabulary: every derived code, every protocol-owned
+        // code a fn invocation can emit, and every explicitly declared
+        // product error. Storage-only reserved codes remain globally owned but
+        // are deliberately not valid on a fn surface.
         let mut vocabulary: HashSet<&str> = tables
             .iter()
             .flat_map(|t| t.errors.iter().map(|e| e.code.as_str()))
             .collect();
-        vocabulary.extend(RESERVED_CODES);
+        vocabulary.extend(FN_RESERVED_CODES);
+        let product_codes: HashSet<&str> = product_errors
+            .iter()
+            .map(|error| error.code.as_str())
+            .collect();
+        vocabulary.extend(product_codes.iter().copied());
         let record_names: HashSet<&str> = records.iter().map(|r| r.name.as_str()).collect();
 
         let mut names: HashMap<&str, Span> = HashMap::new();
@@ -528,13 +609,10 @@ impl Checker {
                 }
             };
 
-            // the `!` clause has two populations (RFD 0012 §2.3): a code
-            // in the vocabulary is a *reference* to a derived or reserved
-            // code; a code in neither is a *refusal minted by this fn* —
-            // raised from the body via spock_refuse(), routed at runtime.
-            // (The cost: a misspelled derived code now mints instead of
-            // erroring — dead metadata, never wrong behavior, since the
-            // real constraint still routes to the true code.)
+            // The `!` clause has three populations: references to derived
+            // codes, references to reserved protocol codes, and explicitly
+            // declared product refusals. Anything else is a typo, not an
+            // implicit declaration.
             let mut errors: Vec<String> = Vec::new();
             let mut refusals: Vec<String> = Vec::new();
             for code in &decl.errors {
@@ -547,6 +625,19 @@ impl Checker {
                     continue;
                 }
                 if !vocabulary.contains(code.name.as_str()) {
+                    let message = if RESERVED_CODES.contains(&code.name.as_str()) {
+                        format!(
+                            "protocol-reserved error code `{}` is not available on a function `!` surface; rename the product refusal and declare the new name at top level",
+                            code.name
+                        )
+                    } else {
+                        format!(
+                            "unknown error code `{}` in the `!` clause; declare it at top level with `error {}`",
+                            code.name, code.name
+                        )
+                    };
+                    self.error("E052", message, code.span);
+                } else if product_codes.contains(code.name.as_str()) {
                     refusals.push(code.name.clone());
                 }
                 errors.push(code.name.clone());
@@ -2672,20 +2763,134 @@ mod tests {
     }
 
     #[test]
-    fn unknown_error_codes_mint_refusals() {
-        // RFD 0012 §2.3: a code in the vocabulary is a reference; a code
-        // in neither population is a refusal minted by this fn
+    fn declared_product_errors_are_order_independent_refusals() {
         let contract = compile(&format!(
-            "{USER}fn f(name: text) -> user ! account_private | user_username_taken | not_found {{ unchecked sql(\"SELECT * FROM user WHERE username = :name\") }}"
+            "{USER}\
+             fn f(name: text) -> user ! account_private | user_username_taken | not_found {{ unchecked sql(\"SELECT * FROM user WHERE username = :name\") }}\n\
+             fn g() -> user? ! account_private {{ unchecked sql(\"SELECT * FROM user LIMIT 1\") }}\n\
+             /// The account is not visible to this actor.\n\
+             error account_private\n\
+             error unused_product_error"
         ))
-        .expect("mints, not errors");
+        .expect("declarations resolve regardless of source order");
+        assert_eq!(contract.errors.len(), 2);
+        assert_eq!(contract.errors[0].code, "account_private");
+        assert_eq!(
+            contract.errors[0].doc.as_deref(),
+            Some("The account is not visible to this actor.")
+        );
+        assert_eq!(contract.errors[1].code, "unused_product_error");
+        assert!(contract.errors[1].doc.is_none());
         let f = &contract.fns[0];
         assert_eq!(
             f.errors,
             vec!["account_private", "user_username_taken", "not_found"]
         );
-        // only the unbacked code is minted — references are not refusals
+        // Only the explicitly declared product code is a refusal; derived and
+        // reserved codes remain references.
         assert_eq!(f.refusals, vec!["account_private"]);
+        assert_eq!(contract.fns[1].refusals, vec!["account_private"]);
+    }
+
+    #[test]
+    fn declarations_alone_do_not_grant_raising() {
+        let contract = compile(&format!(
+            "{USER}error account_private\n\
+             fn f() -> user {{ unchecked sql(\"S\") }}"
+        ))
+        .unwrap();
+        assert_eq!(contract.errors[0].code, "account_private");
+        assert!(contract.fns[0].errors.is_empty());
+        assert!(contract.fns[0].refusals.is_empty());
+    }
+
+    #[test]
+    fn e051_duplicate_error_declaration() {
+        assert_eq!(
+            codes("error account_private\nerror account_private"),
+            vec!["E051"]
+        );
+    }
+
+    #[test]
+    fn e052_unknown_error_code_in_fn_clause() {
+        assert_eq!(
+            codes(&format!(
+                "{USER}fn f() -> user ! account_private {{ unchecked sql(\"S\") }}"
+            )),
+            vec!["E052"]
+        );
+    }
+
+    #[test]
+    fn e052_storage_only_reserved_code_in_fn_clause() {
+        for code in [UNAUTHORIZED_CODE, CONFLICT_CODE] {
+            let diagnostics = compile(&format!(
+                "{USER}fn f() -> user ! {code} {{ unchecked sql(\"S\") }}"
+            ))
+            .unwrap_err();
+            assert_eq!(
+                diagnostics.iter().map(|d| d.code).collect::<Vec<_>>(),
+                vec!["E052"],
+                "{code}"
+            );
+            assert!(
+                diagnostics[0]
+                    .message
+                    .contains("is not available on a function `!` surface"),
+                "{}",
+                diagnostics[0].message
+            );
+        }
+    }
+
+    #[test]
+    fn e053_error_declaration_collision() {
+        for code in RESERVED_CODES {
+            assert_eq!(codes(&format!("error {code}")), vec!["E053"], "{code}");
+        }
+
+        let all_derived_kinds = "table account { key id: uuid = auto\n\
+                                   slug: text unique\n\
+                                   mode: \"open\" | \"closed\" }\n\
+                                 table entry { key id: uuid = auto\n\
+                                   account: account }\n";
+        for code in [
+            "account_already_exists",
+            "account_slug_taken",
+            "account_slug_required",
+            "entry_account_not_found",
+            "account_restricted",
+            "account_mode_invalid",
+        ] {
+            assert_eq!(
+                codes(&format!("{all_derived_kinds}error {code}")),
+                vec!["E053"],
+                "{code}"
+            );
+        }
+
+        let diagnostics = compile(&format!("{USER}error user_username_taken")).unwrap_err();
+        assert!(
+            diagnostics[0]
+                .message
+                .contains("owned by table `user` over field(s) `username`"),
+            "{}",
+            diagnostics[0].message
+        );
+    }
+
+    #[test]
+    fn product_error_namespace_is_separate_from_types_and_fns() {
+        let contract = compile(
+            "table account_private { key id: uuid = auto }\n\
+             fn account_private() -> bool { unchecked sql(\"SELECT true\") }\n\
+             error account_private",
+        )
+        .unwrap();
+        assert_eq!(contract.errors[0].code, "account_private");
+        assert!(contract.table("account_private").is_some());
+        assert!(contract.fn_def("account_private").is_some());
     }
 
     // --- file() seed assets (RFD 0018) ---

--- a/crates/spock-lang/src/ir.rs
+++ b/crates/spock-lang/src/ir.rs
@@ -20,6 +20,11 @@ pub struct Contract {
     /// Additive under `spock: "v0"`; absent when undocumented.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub doc: Option<String>,
+    /// Authored product-error vocabulary. Declaring a code does not make any
+    /// function raise it; a function opts in through its `!` clause.
+    /// Additive under `spock: "v0"`.
+    #[serde(default)]
+    pub errors: Vec<ErrorDef>,
     pub tables: Vec<Table>,
     /// Named wire shapes (fn returns). Additive under `spock: "v0"` —
     /// `default` keeps pre-record contract JSON deserializable.
@@ -30,6 +35,15 @@ pub struct Contract {
     #[serde(default)]
     pub fns: Vec<FnDef>,
     pub seed: Vec<SeedRow>,
+}
+
+/// An explicitly declared, contract-global product-error symbol.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ErrorDef {
+    pub code: String,
+    /// The `///` docs preceding the declaration. Additive.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub doc: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -236,13 +250,13 @@ pub struct FnDef {
     pub readonly: bool,
     pub params: Vec<FnParam>,
     pub returns: FnReturn,
-    /// Declared error codes (`! a | b`) — metadata for introspection and
+    /// Error codes named by `! a | b` — metadata for introspection and
     /// clients; the runtime surfaces undeclared errors truthfully too.
     /// Refusals (see below) are included: `errors` is the full declared
     /// failure surface.
     pub errors: Vec<String>,
-    /// The subset of `errors` this fn *mints* (RFD 0012 §2.3): codes
-    /// backed by no constraint, raised from the body via
+    /// The subset of `errors` that are explicitly declared product errors:
+    /// codes backed by no constraint, raised from the body via
     /// `spock_refuse('<code>')` and routed only if declared here. Pre-v2
     /// JSON has no field; empty is correct — nothing was minted.
     #[serde(default)]
@@ -307,15 +321,38 @@ impl FnReturn {
     }
 }
 
-/// The reserved non-derived error codes (§6.1) — protocol-owned, frozen
-/// for v0.x. The one home: the checker's `!`-clause vocabulary and the
-/// TS emission both read from here, so the set cannot drift per crate.
-pub const RESERVED_CODES: [&str; 5] = [
-    "not_found",
-    "type_mismatch",
-    "unknown_field",
-    "bad_request",
-    "internal",
+/// The reserved non-derived error codes (§6.1, §8.3) — protocol-owned, frozen
+/// for v0.x. The one home: the checker, emitters, and runtime constructors all
+/// read these constants, so spellings cannot drift per crate.
+pub const NOT_FOUND_CODE: &str = "not_found";
+pub const TYPE_MISMATCH_CODE: &str = "type_mismatch";
+pub const UNKNOWN_FIELD_CODE: &str = "unknown_field";
+pub const BAD_REQUEST_CODE: &str = "bad_request";
+pub const INTERNAL_CODE: &str = "internal";
+pub const UNAUTHORIZED_CODE: &str = "unauthorized";
+pub const CONFLICT_CODE: &str = "conflict";
+
+pub const RESERVED_CODES: [&str; 7] = [
+    NOT_FOUND_CODE,
+    TYPE_MISMATCH_CODE,
+    UNKNOWN_FIELD_CODE,
+    BAD_REQUEST_CODE,
+    INTERNAL_CODE,
+    UNAUTHORIZED_CODE,
+    CONFLICT_CODE,
+];
+
+/// Protocol-owned codes that may appear on a function's declared failure
+/// surface. `unauthorized` and `conflict` are owned exclusively by the
+/// storage plane, so accepting them in `fn !` would silently reinterpret old
+/// product refusals while giving the function no mechanism that can emit
+/// them.
+pub const FN_RESERVED_CODES: [&str; 5] = [
+    NOT_FOUND_CODE,
+    TYPE_MISMATCH_CODE,
+    UNKNOWN_FIELD_CODE,
+    BAD_REQUEST_CODE,
+    INTERNAL_CODE,
 ];
 
 /// Resolve a builtin scalar type name (as `FnReturn::of` carries it).
@@ -510,6 +547,16 @@ mod tests {
         let contract = Contract {
             spock: "v0".into(),
             doc: Some("the whole contract".into()),
+            errors: vec![
+                ErrorDef {
+                    code: "account_private".into(),
+                    doc: Some("The account is not visible to this actor.".into()),
+                },
+                ErrorDef {
+                    code: "follow_self".into(),
+                    doc: None,
+                },
+            ],
             tables: vec![Table {
                 name: "user".into(),
                 doc: Some("a person".into()),
@@ -618,6 +665,11 @@ mod tests {
         assert!(json.contains("\"doc\": \"the whole contract\""));
         assert!(json.contains("\"doc\": \"a person\""));
         assert!(json.contains("\"doc\": \"rename a user\""));
+        assert!(json.contains("\"code\": \"account_private\""));
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["errors"][0]["code"], "account_private");
+        assert_eq!(value["errors"][1]["code"], "follow_self");
+        assert!(value["errors"][1].get("doc").is_none());
 
         let back: Contract = serde_json::from_str(&json).unwrap();
         assert_eq!(back.tables[0].name, "user");
@@ -631,6 +683,11 @@ mod tests {
         assert_eq!(back.fns[0].doc.as_deref(), Some("rename a user"));
         assert_eq!(back.fns[0].params[1].doc.as_deref(), Some("the new handle"));
         assert_eq!(back.fns[0].errors, vec!["user_username_taken"]);
+        assert_eq!(back.errors[0].code, "account_private");
+        assert_eq!(
+            back.errors[0].doc.as_deref(),
+            Some("The account is not visible to this actor.")
+        );
         assert_eq!(back.records[0].fields[0].name, "posts");
         assert!(matches!(
             back.seed[0].fields.get("invited_by"),
@@ -663,6 +720,7 @@ mod tests {
         let contract: Contract = serde_json::from_str(legacy).unwrap();
         assert!(contract.fns.is_empty());
         assert!(contract.records.is_empty());
+        assert!(contract.errors.is_empty());
         // a pre-doc contract has no `doc` (RFD 0016 additive under `spock: "v0"`)
         assert!(contract.doc.is_none());
 

--- a/crates/spock-lang/src/lexer.rs
+++ b/crates/spock-lang/src/lexer.rs
@@ -38,6 +38,7 @@ pub enum TokenKind {
     KwTable,
     KwAuth,
     KwRecord,
+    KwError,
     KwFn,
     KwMut,
     KwKey,
@@ -102,6 +103,7 @@ pub(crate) const ACTIVE_KEYWORDS: &[(&str, TokenKind)] = &[
     ("table", TokenKind::KwTable),
     ("auth", TokenKind::KwAuth),
     ("record", TokenKind::KwRecord),
+    ("error", TokenKind::KwError),
     ("fn", TokenKind::KwFn),
     ("mut", TokenKind::KwMut),
     ("key", TokenKind::KwKey),
@@ -141,7 +143,6 @@ pub(crate) const RESERVED_KEYWORDS: &[&str] = &[
     "view",
     "role",
     "policy",
-    "error",
     "state",
     "extern",
     "unsafe",
@@ -593,12 +594,13 @@ mod tests {
     }
 
     #[test]
-    fn fn_and_record_are_active_keywords() {
+    fn fn_record_and_error_are_active_keywords() {
         assert_eq!(
-            kinds("fn record mut"),
+            kinds("fn record error mut"),
             vec![
                 TokenKind::KwFn,
                 TokenKind::KwRecord,
+                TokenKind::KwError,
                 TokenKind::KwMut,
                 TokenKind::Eof
             ]

--- a/crates/spock-lang/src/parser.rs
+++ b/crates/spock-lang/src/parser.rs
@@ -176,13 +176,14 @@ impl Parser {
         }
     }
 
-    // file = { table_decl | record_decl | fn_decl | seed_block }
+    // file = { table_decl | record_decl | error_decl | fn_decl | seed_block }
     fn file(&mut self) -> Result<File, Diagnostic> {
         // `//!` lines in the preamble (before any declaration) document the
         // contract itself (RFD 0016).
         let doc = self.take_inner_doc(0);
         let mut tables = Vec::new();
         let mut records = Vec::new();
+        let mut errors = Vec::new();
         let mut fns = Vec::new();
         let mut seeds = Vec::new();
         loop {
@@ -214,6 +215,11 @@ impl Parser {
                     decl.doc = self.take_outer_doc(at);
                     records.push(decl);
                 }
+                TokenKind::KwError => {
+                    let mut decl = self.error_decl()?;
+                    decl.doc = self.take_outer_doc(at);
+                    errors.push(decl);
+                }
                 TokenKind::KwFn => {
                     let mut decl = self.fn_decl(false)?;
                     decl.doc = self.take_outer_doc(at);
@@ -234,8 +240,9 @@ impl Parser {
                 TokenKind::KwSeed => seeds.push(self.seed_block()?),
                 TokenKind::Eof => break,
                 _ => {
-                    return Err(self
-                        .unexpected("`table`, `auth table`, `record`, `fn`, `mut fn`, or `seed`"));
+                    return Err(self.unexpected(
+                        "`table`, `auth table`, `record`, `error`, `fn`, `mut fn`, or `seed`",
+                    ));
                 }
             }
         }
@@ -247,8 +254,20 @@ impl Parser {
             doc,
             tables,
             records,
+            errors,
             fns,
             seeds,
+        })
+    }
+
+    // error_decl = "error" ident
+    fn error_decl(&mut self) -> Result<ErrorDecl, Diagnostic> {
+        let start = self.expect(TokenKind::KwError, "`error`")?.span;
+        let name = self.ident("error code")?;
+        Ok(ErrorDecl {
+            doc: None,
+            span: start.to(name.span),
+            name,
         })
     }
 
@@ -1108,6 +1127,23 @@ mod tests {
     }
 
     #[test]
+    fn parses_error_declarations() {
+        let file = parse_ok(
+            "/// The account is not visible to this actor.\n\
+             error account_private\n\
+             error request_expired",
+        );
+        assert_eq!(file.errors.len(), 2);
+        assert_eq!(file.errors[0].name.name, "account_private");
+        assert_eq!(
+            file.errors[0].doc.as_deref(),
+            Some("The account is not visible to this actor.")
+        );
+        assert_eq!(file.errors[1].name.name, "request_expired");
+        assert!(file.errors[1].doc.is_none());
+    }
+
+    #[test]
     fn parses_polarity_markers() {
         let file = parse_ok(
             "mut fn rename(user: user, name: text) -> user { unchecked sql(\"S\") }\n\
@@ -1276,6 +1312,8 @@ mod tests {
              }\n\
              /// a wire shape\n\
              record stats { /// how many\n posts: int }\n\
+             /// account cannot be viewed\n\
+             error account_private\n\
              /// rename someone\n\
              mut fn rename(\n\
                /// the target\n\
@@ -1299,6 +1337,11 @@ mod tests {
             panic!("expected field");
         };
         assert_eq!(posts.doc.as_deref(), Some("how many"));
+        // product-error declaration doc
+        assert_eq!(
+            file.errors[0].doc.as_deref(),
+            Some("account cannot be viewed")
+        );
         // fn doc across the `mut` prefix, plus per-parameter docs
         assert_eq!(file.fns[0].doc.as_deref(), Some("rename someone"));
         assert_eq!(file.fns[0].params[0].doc.as_deref(), Some("the target"));

--- a/crates/spock-lang/src/typescript.rs
+++ b/crates/spock-lang/src/typescript.rs
@@ -1,7 +1,7 @@
 //! TypeScript emission (docs/rfd/0010-client-codegen-architecture.md §4).
 //!
 //! The contract as types: per table, the row shape, what insert and update
-//! accept, and the derived error vocabulary as literal unions — plus one
+//! accept, and the derived/product error vocabulary as literal unions — plus one
 //! `contract` map tying them together (the generic parameter a client
 //! takes). A sibling of the SQLite DDL emission: another conformance of
 //! the IR, versioned with the language.
@@ -217,7 +217,7 @@ pub fn typescript(contract: &Contract) -> Result<String, TsGenError> {
         emit_fn_args(&mut out, contract, f);
     }
 
-    out.push_str("\n/** Reserved non-derived codes (docs/spec/v0.md §6.1). */\n");
+    out.push_str("\n/** Reserved protocol codes (docs/spec/v0.md §§6.1, 8.3). */\n");
     out.push_str("export type reserved_error =\n");
     for (i, code) in crate::ir::RESERVED_CODES.iter().enumerate() {
         let end = if i + 1 == crate::ir::RESERVED_CODES.len() {
@@ -228,9 +228,10 @@ pub fn typescript(contract: &Contract) -> Result<String, TsGenError> {
         let _ = writeln!(out, "  | \"{code}\"{end}");
     }
 
-    // refusals minted by fns (§7.4) join the total union — `error_code`
-    // is "everything this contract can produce" (RFD 0010 §4), and the
-    // runtime demonstrably produces these
+    // Product refusals used by fns join the total union — `error_code` is
+    // "everything this contract can produce" (RFD 0010 §4). Keep deriving
+    // the value set from FnDef.refusals for old-contract compatibility;
+    // Contract.errors supplies declaration docs when present.
     let mut refusals: Vec<&str> = contract
         .fns
         .iter()
@@ -239,9 +240,15 @@ pub fn typescript(contract: &Contract) -> Result<String, TsGenError> {
     refusals.sort_unstable();
     refusals.dedup();
     if !refusals.is_empty() {
-        out.push_str("\n/** Refusals minted by fns (docs/spec/v0.md §7.4). */\n");
+        out.push_str("\n/** Explicit product refusals used by fns. */\n");
         out.push_str("export type refusal_code =\n");
         for (i, code) in refusals.iter().enumerate() {
+            let doc = contract
+                .errors
+                .iter()
+                .find(|error| error.code == *code)
+                .and_then(|error| error.doc.as_deref());
+            emit_jsdoc(&mut out, "  ", doc, None);
             let end = if i + 1 == refusals.len() { ";" } else { "" };
             let _ = writeln!(out, "  | \"{code}\"{end}");
         }
@@ -621,6 +628,34 @@ mod tests {
     }
 
     #[test]
+    fn explicit_refusals_carry_declaration_docs() {
+        let source = "/// The account is not visible to this actor.\n\
+                      error account_private\n\
+                      error unused_product_error\n\
+                      table user { key id: uuid = auto\n name: text }\n\
+                      fn find() -> user ! account_private { unchecked sql(\"S\") }";
+        let ts = emit(source).unwrap();
+        assert!(
+            ts.contains(
+                "export type refusal_code =\n  /**\n   * The account is not visible to this actor.\n   */\n  | \"account_private\";"
+            ),
+            "{ts}"
+        );
+        assert!(ts.contains("  | refusal_code\n"), "{ts}");
+        assert!(!ts.contains("\"unused_product_error\""), "{ts}");
+
+        // Old contract JSON can carry FnDef.refusals without Contract.errors;
+        // the emitted value set remains backward-compatible, only docless.
+        let mut contract = crate::compile(source).unwrap();
+        contract.errors.clear();
+        let legacy_ts = typescript(&contract).unwrap();
+        assert!(
+            legacy_ts.contains("  | \"account_private\";"),
+            "{legacy_ts}"
+        );
+    }
+
+    #[test]
     fn pure_key_table_has_no_update_shape() {
         let ts = emit(
             "table user { key id: uuid = auto\n a: int }\n\
@@ -688,13 +723,15 @@ export type user_error =
   | "user_username_taken"
   | "user_username_required";
 
-/** Reserved non-derived codes (docs/spec/v0.md §6.1). */
+/** Reserved protocol codes (docs/spec/v0.md §§6.1, 8.3). */
 export type reserved_error =
   | "not_found"
   | "type_mismatch"
   | "unknown_field"
   | "bad_request"
-  | "internal";
+  | "internal"
+  | "unauthorized"
+  | "conflict";
 
 /** Every error code this contract can produce. */
 export type error_code =

--- a/crates/spock-runtime/src/error.rs
+++ b/crates/spock-runtime/src/error.rs
@@ -4,10 +4,14 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
 use serde_json::json;
-use spock_lang::ir::{DerivedError, ErrorKind};
+use spock_lang::ir::{
+    DerivedError, ErrorKind, BAD_REQUEST_CODE, CONFLICT_CODE, INTERNAL_CODE, NOT_FOUND_CODE,
+    TYPE_MISMATCH_CODE, UNAUTHORIZED_CODE, UNKNOWN_FIELD_CODE,
+};
 
-/// An error as it leaves the runtime: derived (schema-owned) or reserved
-/// (protocol-owned). Renders as the §8.1 envelope.
+/// An error as it leaves the runtime: derived (schema-owned), reserved
+/// (protocol-owned), or an authored product refusal. Renders as the §8.1
+/// envelope.
 #[derive(Clone, Debug)]
 pub struct ApiError {
     pub status: u16,
@@ -33,8 +37,8 @@ impl ApiError {
     pub fn bad_request(message: impl Into<String>) -> Self {
         ApiError {
             status: 400,
-            code: "bad_request".into(),
-            kind: "bad_request",
+            code: BAD_REQUEST_CODE.into(),
+            kind: BAD_REQUEST_CODE,
             table: None,
             fields: vec![],
             message: message.into(),
@@ -44,8 +48,8 @@ impl ApiError {
     pub fn not_found(message: impl Into<String>) -> Self {
         ApiError {
             status: 404,
-            code: "not_found".into(),
-            kind: "not_found",
+            code: NOT_FOUND_CODE.into(),
+            kind: NOT_FOUND_CODE,
             table: None,
             fields: vec![],
             message: message.into(),
@@ -55,8 +59,8 @@ impl ApiError {
     pub fn unknown_field(table: &str, field: &str) -> Self {
         ApiError {
             status: 422,
-            code: "unknown_field".into(),
-            kind: "unknown_field",
+            code: UNKNOWN_FIELD_CODE.into(),
+            kind: UNKNOWN_FIELD_CODE,
             table: Some(table.to_string()),
             fields: vec![field.to_string()],
             message: format!("`{table}` has no field `{field}`"),
@@ -66,8 +70,8 @@ impl ApiError {
     pub fn type_mismatch(table: &str, field: &str, expected: &str) -> Self {
         ApiError {
             status: 422,
-            code: "type_mismatch".into(),
-            kind: "type_mismatch",
+            code: TYPE_MISMATCH_CODE.into(),
+            kind: TYPE_MISMATCH_CODE,
             table: Some(table.to_string()),
             fields: vec![field.to_string()],
             message: format!("`{table}.{field}` expects {expected}"),
@@ -79,8 +83,8 @@ impl ApiError {
     pub fn fn_arg_mismatch(fn_name: &str, param: &str, expected: &str) -> Self {
         ApiError {
             status: 422,
-            code: "type_mismatch".into(),
-            kind: "type_mismatch",
+            code: TYPE_MISMATCH_CODE.into(),
+            kind: TYPE_MISMATCH_CODE,
             table: None,
             fields: vec![param.to_string()],
             message: format!("fn `{fn_name}` argument `{param}` expects {expected}"),
@@ -91,16 +95,16 @@ impl ApiError {
     pub fn fn_unknown_arg(fn_name: &str, arg: &str) -> Self {
         ApiError {
             status: 422,
-            code: "unknown_field".into(),
-            kind: "unknown_field",
+            code: UNKNOWN_FIELD_CODE.into(),
+            kind: UNKNOWN_FIELD_CODE,
             table: None,
             fields: vec![arg.to_string()],
             message: format!("fn `{fn_name}` has no parameter `{arg}`"),
         }
     }
 
-    /// A refusal the fn minted in its `!` clause and raised from the
-    /// body via `spock_refuse` (§7.4, RFD 0012). The conflict family —
+    /// A declared product error the fn lists in its `!` clause and raises
+    /// from the body via `spock_refuse` (§7.4, RFD 0012). The conflict family —
     /// a product rule said no — beside the derived constraint
     /// violations.
     pub fn refused(code: &str, fn_name: &str) -> Self {
@@ -119,8 +123,8 @@ impl ApiError {
     pub fn method_not_allowed(message: impl Into<String>) -> Self {
         ApiError {
             status: 405,
-            code: "bad_request".into(),
-            kind: "bad_request",
+            code: BAD_REQUEST_CODE.into(),
+            kind: BAD_REQUEST_CODE,
             table: None,
             fields: vec![],
             message: message.into(),
@@ -130,8 +134,8 @@ impl ApiError {
     pub fn internal(message: impl Into<String>) -> Self {
         ApiError {
             status: 500,
-            code: "internal".into(),
-            kind: "internal",
+            code: INTERNAL_CODE.into(),
+            kind: INTERNAL_CODE,
             table: None,
             fields: vec![],
             message: message.into(),
@@ -143,8 +147,8 @@ impl ApiError {
     pub fn unauthorized(message: impl Into<String>) -> Self {
         ApiError {
             status: 401,
-            code: "unauthorized".into(),
-            kind: "unauthorized",
+            code: UNAUTHORIZED_CODE.into(),
+            kind: UNAUTHORIZED_CODE,
             table: None,
             fields: vec![],
             message: message.into(),
@@ -156,8 +160,8 @@ impl ApiError {
     pub fn conflict(message: impl Into<String>) -> Self {
         ApiError {
             status: 409,
-            code: "conflict".into(),
-            kind: "conflict",
+            code: CONFLICT_CODE.into(),
+            kind: CONFLICT_CODE,
             table: None,
             fields: vec![],
             message: message.into(),
@@ -197,5 +201,35 @@ impl IntoResponse for ApiError {
             }
         });
         (status, Json(body)).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use spock_lang::ir::RESERVED_CODES;
+
+    #[test]
+    fn fixed_protocol_errors_share_the_language_registry() {
+        let errors = [
+            ApiError::bad_request("x"),
+            ApiError::not_found("x"),
+            ApiError::unknown_field("t", "f"),
+            ApiError::type_mismatch("t", "f", "text"),
+            ApiError::fn_arg_mismatch("f", "p", "text"),
+            ApiError::fn_unknown_arg("f", "p"),
+            ApiError::method_not_allowed("x"),
+            ApiError::internal("x"),
+            ApiError::unauthorized("x"),
+            ApiError::conflict("x"),
+        ];
+
+        for error in errors {
+            assert!(
+                RESERVED_CODES.contains(&error.code.as_str()),
+                "runtime code `{}` is absent from the language registry",
+                error.code
+            );
+        }
     }
 }

--- a/crates/spock-runtime/src/func.rs
+++ b/crates/spock-runtime/src/func.rs
@@ -19,12 +19,12 @@ use crate::write::map_fn_engine_error;
 /// Route a rusqlite failure inside a fn body (§7.4). The refusal channel
 /// is checked first: `spock_refuse('<code>')` errors with a
 /// sentinel-prefixed message, and the code routes **only** if this fn
-/// minted it in its `!` clause — a declared derived or reserved code can
-/// only be produced by its own mechanism (raising one would let a body
-/// counterfeit evidence), and an unminted code is the body breaking its
-/// signature; both are `internal`. Everything else falls through to the
-/// cross-table constraint router. No vocabulary scan: the checker already
-/// stored the mint/reference partition (`refusals ⊆ errors`).
+/// lists it as a declared product error in its `!` clause — a derived or
+/// reserved code can only be produced by its own mechanism (raising one
+/// would let a body counterfeit evidence), and an unlisted code is the
+/// body breaking its signature; both are `internal`. Everything else falls
+/// through to the cross-table constraint router. No vocabulary scan: the
+/// checker already stored the product/reference partition (`refusals ⊆ errors`).
 fn map_fn_call_error(contract: &Contract, f: &FnDef, e: rusqlite::Error) -> ApiError {
     if let rusqlite::Error::SqliteFailure(_, Some(msg)) = &e {
         if let Some(code) = msg.strip_prefix(crate::engine::REFUSE_SENTINEL) {
@@ -250,6 +250,10 @@ table post {
 
 record stats { posts: int }
 record ratio { value: float }
+
+error name_reserved
+error bio_missing
+error always_no
 
 mut fn rename_user(user: user, username: text) -> user ! user_username_taken {
   unchecked sql("UPDATE user SET username = :username WHERE id = :user RETURNING *")
@@ -698,7 +702,7 @@ seed {
         )
         .unwrap();
         assert_eq!(hit, "photographer");
-        // a minted refusal fires with its own name — no more collapsed
+        // a declared product refusal fires with its own name — no more collapsed
         // not_found lies (v0-FEEDBACK G2)
         let f = contract.fn_def("guarded_rename").unwrap();
         let err = call(
@@ -721,7 +725,7 @@ seed {
         )
         .unwrap();
         assert_eq!(row["username"], "maya_ok");
-        // an unminted raise is the body breaking its signature
+        // an unlisted raise is the body breaking its signature
         let f = contract.fn_def("rogue").unwrap();
         let err = call(
             &contract,

--- a/crates/spock-runtime/studio/src/components/err-codes.tsx
+++ b/crates/spock-runtime/studio/src/components/err-codes.tsx
@@ -7,7 +7,7 @@ export interface ErrCode {
 }
 
 // Presentational only (no state) — the declared failure surface: errors[] with
-// the minted refusals[] subset marked (✦). Refusals get a stronger neutral
+// the product refusals[] subset marked (✦). Refusals get a stronger neutral
 // border; nothing is colored but genuine errors elsewhere.
 export function ErrCodes({ codes }: { codes: ErrCode[] }) {
   if (!codes.length) return <span className="text-muted-foreground">—</span>

--- a/crates/spock-runtime/studio/src/types.ts
+++ b/crates/spock-runtime/studio/src/types.ts
@@ -27,6 +27,11 @@ export interface DerivedError {
   kind?: string
 }
 
+export interface ProductError {
+  code: string
+  doc?: string | null
+}
+
 export interface Table {
   name: string
   doc?: string | null
@@ -79,6 +84,8 @@ export interface FnDef {
 export interface Contract {
   spock: string
   doc?: string | null
+  // Optional for contracts compiled before RFD 0024's branch prototype.
+  errors?: ProductError[]
   module?: string
   name?: string
   tables: Table[]

--- a/crates/spock-runtime/studio/src/views/overview.tsx
+++ b/crates/spock-runtime/studio/src/views/overview.tsx
@@ -121,9 +121,43 @@ export class Overview extends Component {
             </div>
           ) : null}
 
+          <SectionLabel>
+            Product error declarations <Badge variant="outline">RFD 0024 prototype</Badge>
+          </SectionLabel>
+          <p className="text-sm text-muted-foreground -mt-1 mb-2">
+            Experimental, unstable, and non-normative on this branch. These are reusable authored
+            outcomes: a declaration creates metadata only, and functions opt in through their own
+            failure lists.
+          </p>
+          <Card className="overflow-hidden p-0">
+            {(contract.errors ?? []).length ? (
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b text-xs uppercase tracking-wide text-muted-foreground">
+                    <th className="text-left font-medium px-3 py-2">Code</th>
+                    <th className="text-left font-medium px-3 py-2">Documentation</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(contract.errors ?? []).map((error) => (
+                    <tr key={error.code} className="border-b last:border-0 align-top">
+                      <td className="px-3 py-2 font-mono">{error.code}</td>
+                      <td className="px-3 py-2">
+                        <Doc text={error.doc} className="text-sm" />
+                        {!error.doc ? <span className="text-muted-foreground">—</span> : null}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            ) : (
+              <div className="px-3 py-3 text-sm text-muted-foreground">none</div>
+            )}
+          </Card>
+
           <SectionLabel>Per-operation outcomes</SectionLabel>
           <p className="text-sm text-muted-foreground -mt-1 mb-2">
-            Every failure each operation can return. Explicit refusals are marked with ✦.
+            Every failure each operation can return. Product refusals are marked with ✦.
           </p>
           <Card className="overflow-hidden p-0">
             <table className="w-full text-sm">

--- a/docs/rfd/0024-error-declarations.md
+++ b/docs/rfd/0024-error-declarations.md
@@ -1,0 +1,594 @@
+---
+rfd: "0024"
+title: Nominal product-error declarations
+authors:
+  - "@softmarshmallow"
+sponsor: "@softmarshmallow"
+shepherd: "@softmarshmallow"
+decision: draft
+implementation: unplanned
+review-start: null
+review-end: null
+tracking-issue: null
+implemented-in: null
+supersedes: []
+superseded-by: null
+---
+
+# RFD 0024 — Nominal product-error declarations
+
+## Summary
+
+Spock should require every authored product-error code in a function's `!`
+clause to resolve to one top-level nominal declaration. The declaration owns a
+stable name and optional documentation; it does not yet define a payload,
+hierarchy, status, message, recovery policy, or new raise mechanism. Derived
+schema errors and protocol-reserved errors remain owned by the compiler and
+runtime and cannot be redeclared.
+
+This is deliberately a small language slot. It fixes name ownership and typo
+detection now while leaving the difficult shape and propagation questions to
+later evidence and separate decisions.
+
+## Problem
+
+RFD 0012 gave functions named product refusals, but it made an otherwise
+unknown identifier in a function's `!` clause mint that refusal locally:
+
+```spock
+mut fn follow(target: user) -> follow ! account_private {
+  unchecked sql("...")
+}
+```
+
+That rule creates three concrete problems:
+
+1. A typo silently creates public metadata. If `account_private` already has
+   product meaning and another function writes `acount_private`, both spellings
+   compile as different refusal codes.
+2. The product error has no declaration site. Documentation and tools must find
+   every function that happens to mention the string before they can learn that
+   the concept exists.
+3. Sharing one product error across operations is accidental string agreement,
+   not name resolution. No declaration owns the public code or provides a
+   stable place for future evolution.
+
+Existing Spock cannot fix these problems with derived errors: a derived code is
+evidence of a particular schema constraint, while a product error names a rule
+implemented by a deliberate operation. Protocol-reserved codes are runtime
+failures and are not application vocabulary. A nominal declaration is the
+smallest construct that distinguishes these categories without prematurely
+designing a complete error type system.
+
+## Goals
+
+- Give each authored product-error code one explicit, inspectable declaration
+  site.
+- Make misspelled or otherwise unknown codes in `fn !` clauses compile errors.
+- Preserve the existing runtime refusal behavior and wire envelope.
+- Carry product errors and their optional docs in an additive, evolvable
+  contract shape.
+- Keep schema-derived, protocol-reserved, and authored product errors in one
+  collision-free public code vocabulary.
+- Reserve a language-owned slot that later RFDs can extend without deciding
+  those extensions here.
+
+## Non-goals
+
+- Structured error payloads or typed fields.
+- Author-authored runtime messages, localization, or presentation copy.
+- Per-error HTTP or GraphQL status selection.
+- Error inheritance, aliases, categories, qualification, or modules.
+- Replacing, wrapping, or customizing derived constraint errors.
+- Error inference, exhaustiveness, reachability, or unused-declaration checks.
+- A checked statement for raising errors; `spock_refuse` remains the v0 escape
+  channel.
+- Error propagation across function calls, effects, jobs, or external systems.
+- Retry, recovery, compensation, observability, or privacy metadata.
+
+## Design-principle fit and tensions
+
+This proposal primarily serves [one authoritative
+representation](../governance/design-principles.md#1-one-authoritative-representation),
+[add contract, not
+distance](../governance/design-principles.md#3-add-contract-not-distance),
+[state once; derive
+deterministically](../governance/design-principles.md#5-state-once-derive-deterministically),
+and [name effects and failure
+boundaries](../governance/design-principles.md#8-name-effects-and-failure-boundaries).
+A product-error name gains one declaration site, function signatures resolve to
+it, and generators consume the resulting contract object.
+
+It also follows [the least powerful sufficient
+language](../governance/design-principles.md#4-prefer-the-least-powerful-sufficient-language):
+`error ident` establishes name ownership and nothing more. Adding payloads,
+inheritance, statuses, or messages without use-case evidence would turn this
+small correctness fix into an unearned error type system.
+
+The tension is compatibility. RFD 0012 intentionally accepted that an unknown
+`!` code minted a refusal. Requiring a declaration breaks those programs at
+check time. Spock is pre-1.0, and the failure is direct and usually fixed by one
+declaration; product codes that collide with protocol-owned names require a
+rename (§Compatibility). The stronger typo and ownership invariant is worth
+that source break if this RFD is accepted.
+
+## Background and evidence
+
+Spock already has three wire-level error populations:
+
+- **derived errors**, whose codes and evidence come from table constraints;
+- **reserved errors**, whose codes and meaning belong to the protocol/runtime;
+  and
+- **product refusals**, raised by a function body through `spock_refuse` and
+  exposed as kind `refused`.
+
+RFD 0012 made product refusals visible in `FnDef.errors` and
+`FnDef.refusals`, but deliberately left global name collisions unenforced and
+noted that a misspelled derived code becomes dead refusal metadata. That was a
+reasonable first slice: it proved named refusal routing without needing a new
+declaration. It is now the evidence for the smaller missing concept—nominal
+ownership—rather than evidence for immediately designing rich errors.
+
+A branch prototype may accompany this draft to test parser, checker, contract,
+and tooling consequences. It is experimental and unstable. Under the [language-change
+process](../governance/language-change-process.md#exploration-before-10), that
+prototype is non-normative evidence: it does not make this draft accepted,
+change supported v0 behavior, or change `implementation: unplanned`.
+
+No language-problem issue or committee triage record is linked yet. This draft
+must not enter public review until that problem record exists and the committee
+confirms that it is mature enough for review.
+
+## Prior art
+
+The [Rust Reference's enum
+model](https://doc.rust-lang.org/reference/items/enumerations.html) demonstrates
+the stronger nominal design: a declaration owns variants and may attach data,
+while matching can be exhaustive. Spock takes only the name-ownership lesson;
+payloads and exhaustiveness are expressly outside this RFD.
+
+[PostgreSQL SQLSTATE
+codes](https://www.postgresql.org/docs/current/errcodes-appendix.html) show the
+value of a stable, centrally owned machine vocabulary. They are a fixed system
+taxonomy, however, not declarations of application-specific product rules.
+
+The [OpenAPI Components
+Object](https://spec.openapis.org/oas/latest.html#components-object) provides a
+reusable object-shaped registry that operations can reference. That supports
+the separation between declaring a reusable concept and listing it on an
+operation, but OpenAPI response objects also decide protocol representation;
+this RFD intentionally does not.
+
+## Proposed design
+
+### Declaration and documentation
+
+A product error is a top-level declaration:
+
+```spock
+/// The current actor may not see this account.
+error account_private
+```
+
+Its grammar is exactly:
+
+```ebnf
+error_decl = "error" ident ;
+```
+
+`error` becomes an active keyword. The declaration has no body and no
+terminator. It may appear anywhere a top-level declaration may appear. Error
+declarations and function error clauses resolve over the whole file as one
+order-independent relation, so a function may reference an error declared
+later in the file.
+
+An outer `///` doc comment may document an `error` under the existing doc
+attachment and normalization rules. The text is contract documentation, not a
+runtime message. An undocumented declaration has no `doc` field in the
+contract. Inner `//!` file documentation is unchanged.
+
+### Namespaces and resolution
+
+Product errors occupy one program-wide **product-error namespace**. It is
+separate from table/record type names and from function names, so this is legal:
+
+```spock
+table account_private { key id: uuid = auto }
+fn account_private() -> bool { unchecked sql("SELECT true") }
+error account_private
+```
+
+The public error-code vocabulary is broader than the declaration namespace. It
+is the union of:
+
+1. schema-derived codes (§6.1 of the v0 specification);
+2. protocol-reserved codes (`not_found`, `type_mismatch`, `unknown_field`,
+   `bad_request`, `internal`, `unauthorized`, and `conflict`); and
+3. explicitly declared product-error codes.
+
+Those three populations must be disjoint. A declaration whose code equals a
+derived or reserved code is invalid; authored code cannot impersonate evidence
+owned by a constraint or the runtime.
+
+`unauthorized` and `conflict` are included because the shipped storage plane
+already emits those codes. This proposal makes their existing protocol
+ownership visible to the checker; it does not add a storage error or change its
+wire behavior.
+
+The global vocabulary is broader than a function's possible failure surface.
+A function's `!` clause may name a declared product error, a derived error, or
+one of the five protocol codes its invocation plane can emit (`not_found`,
+`type_mismatch`, `unknown_field`, `bad_request`, and `internal`). The
+storage-only `unauthorized` and `conflict` codes remain reserved globally but
+are invalid in a function `!` clause. This restriction makes an old implicit
+product refusal with either spelling fail checking instead of silently
+changing from a raisable refusal into unreachable metadata. Resolution is
+order-independent.
+
+A declared product error does not automatically belong to every function. A
+function may raise it through the existing v0 mechanism only when its own `!`
+clause names it. Multiple functions may name the same declared product error.
+A declaration may be unused; this RFD adds no reachability or lint rule.
+
+### Diagnostics
+
+The following diagnostics are normative if this RFD is accepted:
+
+- **E051** — two top-level `error` declarations use the same identifier;
+- **E052** — a code in a function `!` clause is neither a declared product
+  error, a derived error, nor a protocol-reserved error available to the
+  function invocation plane; and
+- **E053** — an explicit product-error declaration collides with a derived or
+  reserved error code.
+
+Existing **E039** continues to diagnose the same code repeated within one
+function's `!` clause. Existing **E044** continues to diagnose collisions
+between derived codes. Diagnostics point at the authored occurrence and should
+identify the conflicting declaration, derivation, or reserved owner when one
+exists.
+
+### Contract IR
+
+The compiled contract gains one additive top-level field:
+
+```json
+{
+  "spock": "v0",
+  "errors": [
+    {
+      "code": "account_private",
+      "doc": "The current actor may not see this account."
+    },
+    {
+      "code": "follow_self"
+    }
+  ]
+}
+```
+
+The IR shape is `Contract.errors: [ErrorDef]`, where each object is:
+
+```text
+ErrorDef {
+  code: string,
+  doc?: string
+}
+```
+
+The array preserves source declaration order for deterministic display; order
+has no semantic meaning. `errors` defaults to `[]` when absent so contracts
+produced before this addition still load. New producers emit the array,
+including an empty array when there are no declarations.
+
+A legacy contract may therefore contain `FnDef.refusals` entries without
+matching top-level objects. Readers preserve and route those historical string
+entries exactly as before; they do not synthesize declarations or docs. The
+resolution invariant applies to contracts newly compiled from source under
+this proposal. This artifact-reading fallback is not source permission to mint
+an undeclared refusal.
+
+The object shape is intentional. A bare string array would be sufficient for
+today's code, but would require a breaking shape change as soon as declarations
+carry any additional contract-owned metadata. The object does **not** reserve
+or decide any particular future field beyond the existing optional `doc`.
+
+`FnDef.errors` remains the function's complete declared failure-code list.
+`FnDef.refusals` remains its subset of product errors that the escape body may
+raise with `spock_refuse`. Both remain string arrays. Each `FnDef.errors` entry
+resolves to a top-level product object, a derived table error, or a
+function-applicable reserved error; every newly compiled `FnDef.refusals`
+entry resolves to a top-level product object. Table-local `errors` arrays
+remain derived-error objects and are unchanged. Legacy-artifact fallback is as
+described above.
+
+### Runtime behavior
+
+Runtime behavior is unchanged:
+
+- a declared product error named in the current function's `!` clause may be
+  raised by `spock_refuse('<code>')`;
+- it uses kind `refused`, REST/`ApiError` status 409, `table: null`, and
+  `fields: []`; GraphQL remains HTTP 200 and omits status from extensions;
+- raising a product error not listed by the current function is `internal`;
+- derived and reserved codes cannot be raised by `spock_refuse`;
+- a refusal rolls back the function transaction; and
+- declaring an error performs no runtime work and creates no new failure path.
+
+The declaration is therefore name ownership and metadata only. It does not
+change the v0 envelope or claim that the deferred semantics below have been
+solved.
+
+### Semantics and invariants
+
+If accepted, the following invariants hold:
+
+1. Every product-error code newly compiled from conforming source has exactly
+   one top-level declaration.
+2. Every code in a newly compiled function `!` clause resolves to exactly one
+   declared, derived, or function-applicable reserved owner.
+3. Declared, derived, and reserved code populations are pairwise disjoint.
+4. A product error may be raised only by a function that lists it.
+5. Declaration order cannot change resolution or runtime behavior.
+6. Documentation cannot affect checking, routing, status, or messages.
+7. Contract consumers can distinguish the declaration registry from each
+   function's selected failure surface without parsing source or SQL.
+
+### Examples
+
+One declaration can be shared by multiple operations and declared after use:
+
+```spock
+mut fn follow(target: user) -> follow
+    ! account_private | follow_self | not_found {
+  unchecked sql("...")
+}
+
+mut fn request_follow(target: user) -> follow_request ! account_private {
+  unchecked sql("...")
+}
+
+/// The target account does not accept this actor's request.
+error account_private
+error follow_self
+```
+
+Here `account_private` and `follow_self` resolve to product declarations,
+`not_found` resolves to a protocol-reserved error, and declaration order is
+irrelevant. A schema-derived code resolves the same way without an authored
+declaration.
+
+An unknown code is rejected rather than minted:
+
+```spock
+error account_private
+
+// E052: `acount_private` resolves nowhere.
+fn profile(target: user) -> profile ! acount_private {
+  unchecked sql("...")
+}
+```
+
+Derived and reserved names cannot be claimed:
+
+```spock
+// E053: owned by the protocol/runtime.
+error not_found
+
+// E053 if this program derives the same unique-constraint code.
+error user_username_taken
+```
+
+Duplicate declarations are invalid even when their docs differ:
+
+```spock
+error account_private
+/// Alternate wording does not create another declaration.
+error account_private // E051
+```
+
+## Alternatives considered
+
+### Keep implicit per-function minting
+
+This preserves source compatibility and keeps the grammar smaller. It also
+preserves the typo hole, leaves shared concepts as accidental string equality,
+and gives documentation no authoritative home. It does not address the stated
+problem.
+
+### Declare errors inside each function
+
+A local declaration would make minting explicit but would not give a shared
+product concept one owner. Reusing a code across functions would still be
+duplicated or would require an additional import/alias system. Top-level
+declarations are smaller and match the program-wide contract vocabulary.
+
+### Scope product codes to function endpoints
+
+Endpoint-scoped namespaces would let an authored `error conflict` coexist with
+the storage protocol's `conflict` code because clients could disambiguate them
+by route and error kind. That preserves two plausible product names and reduces
+migration breakage. It also means the same public code string has multiple
+owners, weakens global code unions and cross-protocol tooling, and makes a
+future shared error registry context-sensitive. This proposal chooses one
+program-wide code vocabulary instead.
+
+### Introduce a complete error enum now
+
+An enum with payloads, variants, exhaustive matching, and hierarchy could solve
+future problems. No current evidence chooses those semantics, and adopting them
+would couple a typo/ownership fix to several difficult decisions. This RFD
+creates the nominal slot without pretending to know its eventual full shape.
+
+### Use string literals in `!` clauses
+
+Quoted strings would make codes visually explicit but would still not declare
+or resolve them. They would worsen typo detection by treating every string as
+valid and would diverge from Spock identifiers and generated code unions.
+
+### Make no language change
+
+Tools could infer product errors by scanning every function's `refusals` list.
+That reproduces the current accidental registry, cannot distinguish a typo from
+a new concept, and provides no source location for shared documentation.
+
+## Compatibility and migration
+
+This is a source-level break for every program that relies on RFD 0012's
+implicit minting. Normally the migration is mechanical: add one top-level
+`error <code>` declaration for each distinct product refusal, optionally move
+shared documentation there, and keep each function's `!` clause unchanged.
+Derived and reserved codes receive no declarations.
+
+There is one deliberate exception. Existing product refusals named
+`unauthorized` or `conflict` collide with codes already owned by the storage
+protocol and must be renamed before declaration. The checker reports E052 for
+either spelling in a function `!` clause even when no declaration was added,
+so unchanged source cannot compile with silently different refusal routing.
+That is a public source and wire-code break for such a program, not an
+automated declaration-only fix. The alternative would be endpoint-scoped code
+namespaces; this RFD instead chooses one collision-free public vocabulary so a
+code has one owner.
+
+`error` was already reserved in v0, so conforming programs could not use it as
+an identifier; activating it creates no additional identifier break.
+
+The contract change is additive under the v0 freeze: new readers default a
+missing top-level `errors` field to `[]`, and the new field uses objects so
+future optional metadata can be additive. Existing `FnDef.errors`,
+`FnDef.refusals`, table error objects, wire envelopes, GraphQL behavior, data,
+and storage behavior are unchanged. New readers continue honoring legacy
+`FnDef.refusals` even when the registry is absent. The generated
+`reserved_error` union widens to include the two already-shipped storage codes.
+
+Rollback before adoption means removing the declarations and restoring
+implicit minting. After adoption, removing a public declaration or renaming its
+code is a public API break even if no function currently raises it; the
+declaration itself places the code in the contract.
+
+## Consequences
+
+**Security and privacy.** Failure routing and wire behavior are unchanged, but
+declarations and their docs become public contract metadata. Authors should
+avoid putting sensitive facts in public code names or docs because the v0
+contract is openly introspectable. The proposal does not solve whether a
+particular refusal leaks sensitive state.
+
+**Performance and operations.** Checking adds only program-wide name-set
+construction and collision checks. The runtime performs no new work. Contract
+size grows by one small object per declared product error.
+
+**Implementation complexity.** Parser, AST, checker, IR serialization, doc
+attachment, generated TypeScript, Studio, and editor syntax need to recognize
+one declaration. The checker must derive the full schema error set before
+finishing collision and function-clause resolution, regardless of source
+order.
+
+**Teachability.** The rule is direct: derive infrastructure failures, declare
+product failures, list operation failures. There is one extra line per shared
+code, offset by one obvious source of truth and typo diagnostics.
+
+**Long-term evolution.** An object-shaped IR and a nominal source slot leave
+room for later proposals. That room is not an implicit acceptance of payloads,
+statuses, hierarchy, or any other deferred feature.
+
+## Implementation and conformance plan
+
+Acceptance would authorize, but does not schedule, the following work:
+
+1. Parse top-level `error ident`, activate the reserved keyword, and attach
+   outer docs.
+2. Add product-error declarations to the checked model and implement E051,
+   E052, and E053 after the full derived/reserved vocabulary is known.
+3. Add `Contract.errors: Vec<ErrorDef>` with a default for old contract JSON;
+   preserve `FnDef.errors` and `FnDef.refusals` semantics.
+4. Update generated TypeScript, Studio/introspection, and editor syntax to read
+   the declaration registry while preserving existing per-function surfaces.
+5. Add parser, checker, serialization/back-compatibility, runtime-regression,
+   codegen, Studio, and editor conformance tests.
+6. While the RFD is draft, keep any branch-only fixture migration prominently
+   marked as non-normative and off supported `main`; migrate maintained
+   examples as supported language only after acceptance.
+7. Reconcile `docs/spec/v0.md`, `docs/spec/graphql.md`, user documentation, and
+   conformance fixtures when supported implementation ships.
+
+Required conformance cases include declarations before and after use; documented
+and undocumented objects; shared use across functions; unused declarations;
+E039/E051/E052/E053; collisions against every derived kind and every reserved
+code; rejection of the two storage-only reserved codes on function surfaces;
+old contracts missing the field; and proof that refusal envelopes and
+transaction rollback are unchanged.
+
+Any implementation on a branch while this RFD is draft is an experimental,
+unstable, non-normative prototype. It must not be presented as supported v0
+behavior or merged into the normative specification before the language-change
+process authorizes it.
+
+## Specification changes
+
+If accepted and implemented, the following normative sections change:
+
+- `docs/spec/v0.md` opening scope and §§1, 2.3, and 2.4: add the declaration and
+  its doc-comment attachment; move `error` from reserved to active;
+- `docs/spec/v0.md` §3: add `error_decl` and the order-independent resolution
+  rules;
+- `docs/spec/v0.md` §4: add E051, E052, and E053 and revise E039's unknown-code
+  note;
+- `docs/spec/v0.md` §§6 and 6.1: add `Contract.errors: [ErrorDef]`, describe its
+  compatibility default and legacy fallback, include the two existing storage
+  codes in the protocol-owned registry, and replace implicit refusal minting
+  with declared product-error resolution;
+- `docs/spec/v0.md` §7.4: preserve runtime raising while requiring a product
+  declaration plus per-function listing; and
+- `docs/spec/graphql.md` §§5.1 and 6: describe declared product errors instead
+  of implicitly minted refusals; the GraphQL schema and envelope do not change.
+
+A proposed spec patch may live beside a branch prototype for review, but it is
+non-normative while this RFD remains draft and implementation remains
+unplanned.
+
+## Unresolved questions
+
+- Which language-problem issue and committee triage record will ground public
+  review?
+- Does the name-ownership rule and source break have sufficient evidence to
+  enter public review?
+- Should an accepted migration provide an automated fix, or is the diagnostic's
+  suggested `error <code>` declaration sufficient at v0 scale?
+- Should declaration order remain visible in the contract, as proposed, or
+  should producers sort by code? This affects deterministic presentation only,
+  not semantics.
+
+Payloads, messages, statuses, hierarchy, aliases, customization of derived
+errors, propagation, exhaustiveness, reachability, and recovery metadata are
+not unresolved details of this proposal. They are explicitly deferred language
+problems requiring their own evidence and decision.
+
+## Decision record
+
+<!-- Maintained by the Language Design Committee. -->
+
+- Decision: not decided
+- Decision date: not applicable
+- Review period: not started
+- Committee participants: not applicable
+- Conflicts and recusals: not applicable
+- Eligible voting members and quorum calculation: not applicable
+- Deliberation record: not applicable
+- Consensus or vote, including names and positions: not applicable
+- Required threshold and whether it was met: not applicable
+- Bootstrap provision used: not applicable
+- Design Steward invoked: no; if yes, record the committee's equivalence
+  finding and link the steward's rationale
+- Rationale: not applicable
+- Material objections and responses: not applicable
+- Dissent: not applicable
+
+## Implementation record
+
+<!-- Update links and state without rewriting the decided design. -->
+
+- Tracking issue: not assigned
+- Implementation pull requests: none
+- Conformance tests: not started
+- Documentation and specification reconciliation: not started
+- Shipped release: not shipped

--- a/docs/rfd/README.md
+++ b/docs/rfd/README.md
@@ -195,6 +195,16 @@ the earlier record. Rejected and superseded RFDs remain in this directory.
 WG notes, prototypes, and examples remain non-normative even when cited by an
 RFD.
 
+## Prospective RFD index
+
+Entries in this table use the current two-axis process. A draft records a
+proposal under development, not an adopted language feature; implementation
+status tracks supported adoption and excludes branch experiments.
+
+| RFD | Title | Decision | Implementation |
+| --- | --- | --- | --- |
+| [0024](0024-error-declarations.md) | Nominal product-error declarations | Draft | Unplanned |
+
 ## Legacy RFD index
 
 Every entry below is a **legacy record**. “Recorded legacy status” closely

--- a/docs/spec/graphql.md
+++ b/docs/spec/graphql.md
@@ -7,6 +7,13 @@ The v0 runtime implements **Tier 1** (§7); higher tiers are the target.
 discipline, error envelope); §9 here records the executed migration from
 the pre-dialect surface.
 
+> **Prospective branch delta — experimental, unstable, and non-normative.**
+> References below to top-level product-error declarations describe the RFD
+> 0024 branch prototype. RFD 0024 remains `decision: draft` and
+> `implementation: unplanned`; the GraphQL shape and envelope are unchanged,
+> and this wording has no normative force unless that RFD is accepted and
+> implemented.
+
 ---
 
 ## 1. Mental model
@@ -181,11 +188,12 @@ engine-enforced, not asserted:
   the failure surface, introspectable before any call. Codes the SQL can
   produce but the signature does not declare still surface truthfully at
   runtime, routed cross-table to the owning table's derived error.
-- Declared codes include **minted refusals** (spec v0 §7.4, RFD 0012):
-  a fn's own product-rule codes, raised from the body, carried in
-  `errors[].extensions` with `kind: "refused"` and `table: null` —
-  distinct names for distinct rules, where v1 collapsed every guard
-  into `not_found`.
+- In the proposed RFD 0024 delta, declared codes include **nominal product
+  errors**: a top-level `error ident` owns the product-rule code, and each fn
+  that can raise it lists it in `!`. The body raises it through the unchanged
+  RFD 0012 refusal path, carried in `errors[].extensions` with
+  `kind: "refused"` and `table: null` — distinct names for distinct rules,
+  where v1 collapsed every guard into `not_found`.
 - **Root names are claimed, per root**: on `Mutation`, derived CRUD
   names and `mut` fn names live in one namespace, and exactly what is
   registered is claimed (a pure-key table claims no update) — a `mut`
@@ -209,7 +217,15 @@ Where Hasura says `constraint-violation`, Spock says which constraint, on
 which table, over which fields — the code was in the contract (and in the
 mutation's description) before any request was made. Reserved
 non-derived codes: `not_found`, `type_mismatch`, `unknown_field`,
-`bad_request`, `internal`.
+`bad_request`, `internal`. The program-wide reserved vocabulary proposed by
+RFD 0024 also includes storage-plane `unauthorized` and `conflict`; GraphQL does
+not emit those two, and a product declaration cannot claim them.
+
+The proposed RFD 0024 product-error registry changes name ownership and
+introspection metadata only. A product error raised by a function keeps the
+same `kind: "refused"` and extensions shape. The underlying REST/`ApiError`
+status remains 409 while GraphQL remains HTTP 200 and omits status; its optional
+declaration doc remains contract metadata, not a runtime message.
 
 A value-constraint violation (RFD 0013) carries `kind: "invalid"`, code
 `<table>_<field>_invalid`. A **closed-set** field stays a GraphQL

--- a/docs/spec/v0.md
+++ b/docs/spec/v0.md
@@ -6,6 +6,17 @@ embedded-SQLite runtime, and a minimal HTTP protocol. Future declarations such
 as `view`, `role`, and `policy` remain deliberately absent and reserved (§2.3)
 so v0 programs stay forward-compatible.
 
+> **Prospective branch delta — experimental, unstable, and non-normative.**
+> This feature branch includes proposed specification text for top-level
+> `error` declarations so the RFD 0024 prototype can be reviewed against an
+> exact target. RFD 0024 remains
+> `decision: draft` and `implementation: unplanned`; its marked additions do
+> not describe supported v0 behavior, change conformance, or imply committee
+> acceptance. On supported `main`, `error` remains reserved and RFD 0012's
+> implicit per-function refusal minting remains current. The proposed text may
+> become normative only after acceptance and full implementation
+> reconciliation under the language-change process.
+
 A conforming implementation accepts exactly the language defined here,
 reports the diagnostics of §4 against non-conforming programs, materializes
 the storage model of §7, and serves the protocol of §8. The compiled contract
@@ -17,9 +28,13 @@ conformance of this document, not its definition (RFD 0006).
 ## 1. Source files
 
 A Spock source file is UTF-8 text, conventionally `*.spock`. A file contains
-zero or more table, record, or function declarations and zero or more `seed`
-blocks, in any order. `auth` modifies a table and `mut` modifies a function.
-Multiple `seed` blocks concatenate in file order.
+zero or more table, record, error, or function declarations and zero or more
+`seed` blocks, in any order. `auth` modifies a table and `mut` modifies a
+function. Multiple `seed` blocks concatenate in file order.
+
+The inclusion of error declarations in this section and the RFD 0024 changes
+marked below are the **proposed, non-normative branch delta** described in the
+opening notice.
 
 Comments run from `//` to end of line. A comment opening with exactly three
 slashes (`///`, an *outer* doc comment) or with `//!` (an *inner* doc comment)
@@ -62,10 +77,13 @@ as identifiers.
 Active in v0:
 
 ```
-table  auth  record  fn  mut  key  unique  check  seed  on  delete  restrict
+table  auth  record  error  fn  mut  key  unique  check  seed  on  delete  restrict
 cascade  set  null  text  int  float  bool  timestamp  uuid
 auto  now  me  true  false
 ```
+
+`error` is active only in the proposed RFD 0024 branch delta. It remains
+reserved in the supported v0 language while that RFD is draft.
 
 `sql` and `unchecked` are *contextual* keywords: they form a fn body (§3)
 but remain legal identifiers everywhere else.
@@ -79,7 +97,7 @@ not source compatibility; v0.x source may still move.)
 Reserved for future versions (using one as an identifier is an error, L005):
 
 ```
-view  role  policy  error  state  extern  unsafe  derived
+view  role  policy  state  extern  unsafe  derived
 protected  module  enum  expect  transition  upsert  match  with
 ```
 
@@ -93,7 +111,8 @@ Two comment forms are **doc comments** (RFD 0016) — carried into the compiled
 contract (§6) rather than discarded:
 
 - `///` — an **outer** doc comment: documents the entity that *follows* it (a
-  `table`, `record`, field, `fn`, or `fn` parameter).
+  `table`, `record`, field, `error`, `fn`, or `fn` parameter). Attachment to
+  `error` is part of the proposed RFD 0024 branch delta.
 - `//!` — an **inner** doc comment: documents the *enclosing* file, i.e. the
   contract. Legal only in the preamble, before the first declaration — spock
   has no modules, so the file is the only scope a `//!` can document.
@@ -116,7 +135,7 @@ the grammar of §3.
 ## 3. Grammar
 
 ```ebnf
-file        = { table_decl | record_decl | fn_decl | seed_block } ;
+file        = { table_decl | record_decl | error_decl | fn_decl | seed_block } ;
 
 table_decl  = [ "auth" ] "table" ident "{" { table_item } "}" ;
               (* `auth table` marks the identity anchor (RFD 0014); at most
@@ -126,6 +145,10 @@ table_item  = key_decl | unique_decl | check_decl | field_decl ;
 record_decl = "record" ident "{" { table_item } "}" ;
               (* items share the table grammar; table-only constructs are
                  rejected by the checker, E033 *)
+
+error_decl  = "error" ident ;
+              (* proposed RFD 0024: a nominal product-error declaration;
+                 top-level resolution is order-independent *)
 
 fn_decl     = [ "mut" ] "fn" ident "(" [ param { "," param } [ "," ] ] ")"
               "->" ret [ "!" ident { "|" ident } ]
@@ -168,6 +191,20 @@ seed_field  = ident ":" seed_value ;
 seed_value  = literal | ident | file_value ;    (* ident = seed binding *)
 file_value  = "file" "(" string ")" ;           (* a seed asset, RFD 0018 *)
 ```
+
+In the proposed RFD 0024 branch delta, `error ident` declares one authored
+product-error code in a program-wide product-error namespace. Error
+declarations and function error clauses resolve over the whole file, so an
+error may be declared before or after a function that names it. The namespace
+is separate from table/record and fn names. It shares the public code
+vocabulary with schema-derived and protocol-reserved errors, which cannot be
+redeclared (E053).
+
+The global reserved vocabulary is broader than the function plane. Function
+`!` clauses may name the five protocol codes a function invocation can emit:
+`not_found`, `type_mismatch`, `unknown_field`, `bad_request`, and `internal`.
+The storage-only `unauthorized` and `conflict` codes remain reserved against
+product declarations but are invalid in a function `!` clause (E052).
 
 Disambiguation: inside a table body, `key` followed by `(` is a composite
 `key_decl`; otherwise it is the inline-key modifier of a `field_decl`.
@@ -257,7 +294,7 @@ fails); L-codes are lexical/parse errors.
 | E036 | fn parameter type unknown, a record, or a composite-key table |
 | E037 | fn return shape is not a declared table or record |
 | E038 | duplicate fn parameter name |
-| E039 | duplicate error code in the `!` clause. (An *unknown* code no longer errors — RFD 0012: a code that is neither derived nor reserved is a refusal **minted** by this fn, §7.4. The cost is honest: a misspelled derived code mints dead metadata instead of failing — never wrong behavior, since the real constraint still routes to the true code at runtime) |
+| E039 | duplicate error code in one fn `!` clause |
 | E040 | `on delete set null` on a required reference (only an optional field can be nulled) |
 | E041 | `check` names a fn that does not exist (RFD 0013) |
 | E042 | `check` validator law violated: not a read fn, not `bool`, not a single clauseless `SELECT`, non-deterministic, wrong arity/param types, or attached to a closed-set/`auto`/`now` field (RFD 0013) |
@@ -269,12 +306,22 @@ fails); L-codes are lexical/parse errors.
 | E048 | a user table is named `storage_object` — the name is reserved for the storage builtin (RFD 0018) |
 | E049 | `file("...")` on a field that does not reference `storage_object` (RFD 0018) |
 | E050 | a `file("...")` seed asset path is absolute or escapes the source directory (RFD 0018) |
+| E051 | two top-level `error` declarations use the same identifier (proposed RFD 0024) |
+| E052 | a code in a fn `!` clause is not a declared product error, a schema-derived error, or a protocol-reserved error available to the function plane (proposed RFD 0024) |
+| E053 | an explicit product-error declaration collides with a schema-derived or protocol-reserved error code (proposed RFD 0024) |
 
 Notes.
 
 - Doc-comment placement is checked by the parser (RFD 0016, §2.4): **L011** —
   a `///` that documents nothing (dangling); **L012** — a `//!` after the
   first declaration (misplaced inner doc).
+
+- Under the proposed RFD 0024 branch delta, a product-error declaration and
+  its uses resolve order-independently. A declaration may be unused. Every
+  code in `!` must resolve to a function-applicable owner (E052), declarations
+  are unique (E051), and authored codes cannot claim derived or reserved
+  ownership (E053). These diagnostics remain non-normative while RFD 0024 is
+  draft.
 
 - E034/E036 also reject a closed-set type in a `record` field / `fn`
   parameter; E009/E023 also reject a set field's default / seed literal
@@ -363,6 +410,10 @@ artifact runtimes load and tools consume. Shape (informative example):
 ```json
 {
   "spock": "v0",
+  "errors": [
+    { "code": "account_private",
+      "doc": "The current actor may not see this account." }
+  ],
   "tables": [
     {
       "name": "user",
@@ -412,7 +463,11 @@ type kind `float`, default kind `float`, float seed values, and
 default kind `actor` (`{ "kind": "actor" }`, the `= me` stamp), and (RFD 0016)
 an optional `doc` string on the contract and on each table, field, record,
 record field, fn, and fn parameter — the `///`/`//!` doc comments, absent when
-undocumented.
+undocumented. The proposed RFD 0024 branch delta adds top-level `errors`, an
+array of `{ "code": string, "doc"?: string }` objects in source declaration
+order. It defaults to `[]` when absent, and `doc` is absent when the error has
+no outer doc comment. The object shape is deliberate so later optional metadata
+can be additive; it does not decide any such metadata now.
 Additive means old JSON keeps loading in new
 consumers — it does not mean old consumers can read a contract that
 uses new vocabulary (a pre-float reader rejects `"kind": "float"`), and
@@ -429,13 +484,24 @@ loading. New contracts always write the array. Fns also carry
 default is `false` because every pre-v2 fn lived on the Mutation
 root — absent means "the mutation it always was". And fns carry
 `refusals` (string array, defaults to `[]`): the subset of `errors`
-this fn mints (§7.4) — `errors` remains the full declared failure
-surface, so consumers that only read `errors` keep seeing everything.
+this fn may raise through `spock_refuse` (§7.4) — `errors` remains the full
+declared failure surface, so consumers that only read `errors` keep seeing
+everything. Under the proposed RFD 0024 delta, every refusal also resolves to
+one object in the contract's top-level product-error registry when newly
+compiled from source; the fn arrays remain strings for compatibility. A legacy
+artifact may have `refusals` but no registry. Readers preserve those strings
+without synthesizing declarations or docs.
 
-### 6.1 Derived errors
+### 6.1 Error vocabulary
 
-No error in v0 is hand-written; every error is derived from the schema. Per
-table:
+The public code vocabulary is the disjoint union of schema-derived errors,
+protocol-reserved errors, and—in the proposed RFD 0024 branch delta—explicitly
+declared product errors. The first two populations remain language-owned and
+cannot be redeclared (E053).
+
+#### Derived errors
+
+Schema-derived errors are never hand-written. Per table:
 
 | Kind | Derived from | Code | Status |
 |---|---|---|---|
@@ -448,19 +514,21 @@ table:
 
 These are part of the contract (§6) — visible to clients before any request
 is made — and the vocabulary is **frozen for v0.x** with the same rule:
-new kinds may be added; the five above, their code-derivation templates,
+new kinds may be added; the six above, their code-derivation templates,
 and the reserved non-derived codes (`not_found`, `type_mismatch`,
-`unknown_field`, `bad_request`, `internal`) do not change meaning or
-spelling. Error codes are API: clients are expected to match on them.
+`unknown_field`, `bad_request`, `internal`, `unauthorized`, `conflict`) do not
+change meaning or spelling. The final two are emitted by the storage plane
+(§8.3) and remain protocol-owned even when a contract does not use storage.
+Error codes are API: clients are expected to match on them.
 
-Since RFD 0012 there is one added kind: **`refused`** — a code a fn
-*mints* in its `!` clause and raises from its body (§7.4). Refusals are
-declared, not derived, but never hand-written at the call site either:
-the signature names the rule, the body raises it, the envelope carries
-it (status 409, `table: null`, `fields: []`). Refusal codes share the
-one code namespace with derived codes; their shape is free-form, and
-nothing prevents a future table from deriving a colliding code — rename
-the refusal if that ever bites.
+Since RFD 0012 there is one added kind: **`refused`** — a product-rule code
+raised from a fn body (§7.4). In the proposed RFD 0024 branch delta, the code is
+owned by a top-level `error ident` declaration and selected by each fn that
+lists it in `!`; an otherwise unknown `!` identifier is E052 rather than a new
+implicit refusal. The body still raises through `spock_refuse`, and the
+REST envelope remains status 409, `table: null`, `fields: []`; GraphQL remains
+HTTP 200 and omits status from extensions (§8.2). Product, derived, and reserved
+codes share one collision-free public vocabulary (E044/E051/E053).
 
 RFD 0013 adds the kind **`invalid`** — a value-constraint violation:
 a closed-set membership miss (§7.1) or a validator-`check` failure. Its
@@ -705,13 +773,19 @@ reserved `bad_request` (the engine reports no table detail for FK
 failures — truth over guessing); anything else is `internal`. The
 declared `! code | code` clause is metadata — introspection and clients
 see it — and codes the body can produce but the signature does not
-declare still surface truthfully.
+declare still surface truthfully. Under the proposed RFD 0024 branch delta,
+each `!` identifier resolves order-independently to a top-level product-error
+declaration, a schema-derived code, or one of the five function-applicable
+protocol-reserved codes; anything else is E052. The storage-only reserved
+codes `unauthorized` and `conflict` are not valid on a function surface.
+Listing a code does not change which constraint or runtime mechanism can
+produce it.
 
-**Refusals** (RFD 0012). A code in the `!` clause that is neither a
-derived code nor a reserved code is a refusal **minted by this fn** — a
-product rule with a name. The body raises it through the engine builtin
-`spock_refuse('<code>')`, which always errors when evaluated — so the
-guard shape is a conditional selection:
+**Refusals** (RFD 0012; proposed RFD 0024 name-ownership delta). A top-level
+`error ident` declares a product rule with a name. A fn that lists that code in
+its `!` clause may raise it through the engine builtin
+`spock_refuse('<code>')`, which always errors when evaluated — so the guard
+shape is a conditional selection:
 
 ```sql
 SELECT spock_refuse('account_private')
@@ -719,17 +793,20 @@ WHERE EXISTS (SELECT 1 FROM user WHERE id = :target AND private)
 ```
 
 Zero rows selected, nothing raised. The runtime routes a raised code
-only if **this fn minted it**: the envelope is the code itself, kind
-`refused`, status 409 (§6.1). Raising anything else is `internal`,
-before commit — an unminted code is the body breaking its signature,
+only if **this fn lists the declared product error**: the envelope is the code
+itself, kind `refused`, REST status 409 (§6.1); GraphQL's HTTP-200 translation
+is unchanged (§8.2). Raising anything else is `internal`,
+before commit — an unlisted code is the body breaking its signature,
 and a derived or reserved code can only be produced by its own
 mechanism: if bodies could raise `user_username_taken` by hand, derived
 errors would stop being evidence. A refusal raised mid-body rolls the
 whole transaction back like any other failure. `spock_refuse` is
-declaration-checked, not reachability-checked: a minted code the body
-never raises is dead metadata, visible in introspection, harmless at
-runtime. Read fns refuse too — `SELECT spock_refuse(...)` is a
-read-only statement.
+signature-checked, not reachability-checked: a declared product error that a fn
+lists but never raises is dead metadata, visible in introspection and harmless
+at runtime. A top-level product declaration may likewise be unused. Read fns
+refuse too — `SELECT spock_refuse(...)` is a read-only statement. The
+declaration adds no runtime path, payload, status choice, or message; those
+semantics are deferred by RFD 0024.
 
 ## 8. HTTP protocol
 
@@ -804,6 +881,10 @@ version and flips the default (RFD 0008; exposure model in RFD 0004). REST
 Validation errors that are not schema-derived (unknown field, type mismatch,
 malformed body) use the reserved codes `unknown_field`, `type_mismatch`,
 `bad_request`, `not_found` with the same envelope.
+
+The storage plane additionally uses reserved `unauthorized` (401) and
+`conflict` (409). They participate in the same public code vocabulary even
+though function and GraphQL paths do not normally produce them.
 
 ### 8.2 GraphQL
 

--- a/editors/vscode/syntaxes/spock.tmLanguage.json
+++ b/editors/vscode/syntaxes/spock.tmLanguage.json
@@ -87,6 +87,13 @@
           }
         },
         {
+          "match": "\\b(error)(\\s+)([a-z_][a-z0-9_]*)",
+          "captures": {
+            "1": { "name": "keyword.declaration.error.spock" },
+            "3": { "name": "constant.other.error.spock" }
+          }
+        },
+        {
           "name": "meta.function.signature.spock",
           "begin": "\\b(?:(mut)(\\s+))?(fn)(\\s+)([a-z_][a-z0-9_]*)(?=\\s*\\()",
           "beginCaptures": {
@@ -141,7 +148,7 @@
       "patterns": [
         {
           "name": "invalid.illegal.reserved.spock",
-          "match": "\\b(?:view|role|policy|error|state|extern|unsafe|derived|protected|module|enum|expect|transition|upsert|match|with)\\b"
+          "match": "\\b(?:view|role|policy|state|extern|unsafe|derived|protected|module|enum|expect|transition|upsert|match|with)\\b"
         }
       ]
     },
@@ -149,7 +156,7 @@
       "patterns": [
         {
           "name": "keyword.declaration.spock",
-          "match": "\\b(?:table|auth|record|fn|mut|seed)\\b"
+          "match": "\\b(?:table|auth|record|fn|mut|error|seed)\\b"
         },
         {
           "name": "keyword.other.constraint.spock",

--- a/editors/vscode/test/corpus.spock
+++ b/editors/vscode/test/corpus.spock
@@ -1,9 +1,14 @@
-//! VS Code TextMate corpus for the implemented Spock v0 language.
+//! VS Code TextMate corpus for the RFD 0024 branch prototype.
 //!
-//! This is both a visual scope fixture and an accepted compiler input.
+//! PROSPECTIVE, EXPERIMENTAL, UNSTABLE, AND NON-NORMATIVE: `error` is active
+//! only on this branch. This is a visual scope fixture and compiler input, not
+//! supported-v0 conformance.
 
 //// Four or more slashes are an ordinary comment, not documentation.
 // Ordinary comments use exactly the same line-comment delimiter.
+
+/// The caller is not allowed to rename the asset.
+error not_allowed
 
 /// Validates the field-level `check` used below.
 fn nonempty(
@@ -67,7 +72,7 @@ fn assets_by_owner(owner: user?) -> [asset] {
   """)
 }
 
-/// A mutation with two declared refusal codes.
+/// A mutation with two named error codes.
 mut fn rename_asset(
   asset_id: uuid,
   title: text,

--- a/examples/instagram/v0.spock
+++ b/examples/instagram/v0.spock
@@ -1,5 +1,9 @@
 //! Instagram — the v0 slice.
 //!
+//! PROSPECTIVE RFD 0024 BRANCH PROTOTYPE — EXPERIMENTAL, UNSTABLE, AND
+//! NON-NORMATIVE. The top-level `error` declarations in this file are branch
+//! evidence, not supported v0.
+//!
 //! A working backend for the core Instagram experience: profiles and the
 //! follow graph (public follows, private-account requests, blocks and
 //! restrictions), posts and their media carousels, likes, comments, saves
@@ -10,10 +14,10 @@
 //! product surface layered over the auto-generated table CRUD — every
 //! mutation names the ways it can refuse.
 
-// This file uses only the implemented v0 surface (docs/spec/v0.md) and runs
-// on the toolchain in crates/:
+// Apart from the marked RFD 0024 declaration prototype, this file uses the
+// implemented v0 surface. Run it with the source toolchain on this branch:
 //
-//   spock run examples/instagram/v0.spock
+//   cargo run --locked -p spock-cli -- run examples/instagram/v0.spock
 //
 // It covers as much of PRD.md as today's language can say: the durable
 // entities, and a deliberate surface of fns over them. What it cannot say —
@@ -42,6 +46,34 @@
 //   - an add-media-tag fn — tag *permissions* (PRD) need the permission
 //     fields above; until then `insert_media_tag_one` on the floor is
 //     the same contract
+
+// ---------------------------------------------------------------------------
+// errors — authored product refusals
+// ---------------------------------------------------------------------------
+
+/// The action is unavailable because one user has blocked the other.
+error blocked
+
+/// The action is unavailable because the target account is private.
+error account_private
+
+/// A follow request is unnecessary because the target account is public.
+error account_public
+
+/// A denied follow request must be requested again before it can be approved.
+error request_denied
+
+/// An approved follow request cannot subsequently be denied.
+error request_approved
+
+/// A reply's parent comment does not exist or belongs to a different post.
+error parent_mismatch
+
+/// The collection does not belong to the acting user.
+error not_owner
+
+/// The post must be saved before it can be added to a collection.
+error not_saved
 
 // ---------------------------------------------------------------------------
 // rules — value validators (RFD 0013)


### PR DESCRIPTION
## Summary

- add top-level `error ident` declarations as a nominal, documented product-error registry
- resolve function `!` entries order-independently and diagnose duplicates, unknown names, and derived/reserved collisions with E051–E053
- preserve the existing refusal envelope while exposing declarations through contract JSON, TypeScript, Studio, editor syntax, specs, and marked fixtures
- carry the matching Instagram migration through merged companion PR [gridaco/uhura#14](https://github.com/gridaco/uhura/pull/14) and sync the gitlink to latest Uhura `main`

**Experimental, unstable, non-normative; ready for repository review as evidence, not for merge; no language adoption requested.** This PR is branch evidence for draft RFD 0024, not the start of formal language review.

## Change classification

- [ ] Language-contract-preserving implementation, tooling, documentation, tests, or refactor
- [ ] Isolated, opt-in, non-normative pre-1.0 experiment or prototype
- [x] Committee-sponsored RFD draft, review revision, or decision record
- [ ] Implementation or specification synchronization authorized by an accepted RFD
- [ ] Non-normative working-group study or meeting record
- [ ] Governance or contribution-process change

The implementation and proposed specification patch accompany the draft as evidence. They change branch-default behavior, so this is not an isolated experiment eligible for merge.

## Language-change gate

- Related issue: Not filed yet; this blocks formal review and merge.
- Language-problem issue: Not filed yet; draft RFD 0024 explicitly records this blocker.
- Committee sponsor/shepherd: @softmarshmallow / @softmarshmallow
- Accepted RFD: None. RFD 0024 remains `decision: draft`, `implementation: unplanned`.
- Implementation tracking issue: None; implementation is not authorized.
- Language-contract preservation: Not preserved on this branch. Implicit refusal minting is replaced by explicit declaration and resolution.
- Experiment boundary: No off-by-default entry point exists. Exposed surfaces are marked experimental, unstable, and non-normative; owner @softmarshmallow; review and expiry dates remain unset. Therefore this draft is evidence only and not merge-eligible.
- Governance public-review dates: None; formal public review has not started.
- Governance decision record: None.

## Before and after

**Before:** An otherwise unknown identifier in a function `!` clause implicitly minted a product refusal. Typos became public metadata, shared errors had no declaration site, and no contract-global object owned their docs.

**After on this prototype branch:** Each authored product refusal must first be declared with `error <code>`; functions select it in `!`. The declaration owns only the stable code and optional docs. Derived and protocol errors remain compiler/runtime-owned. Unknown codes fail with E052 instead of minting.

## Scope and tradeoffs

This proposal deliberately does **not** decide payloads, hierarchy, status selection, messages, localization, propagation, exhaustiveness, retry policy, or a new raise mechanism.

The source break is normally mechanical: add one declaration per distinct product refusal. Existing implicit product refusals named `unauthorized` or `conflict` must be renamed because those codes are storage-owned; E052 prevents them from silently changing runtime meaning. Old contract JSON without `errors` still loads, and existing wire envelopes and rollback behavior are unchanged.

Uhura #14 merged as `f13a4d9`. The parent gitlink now points to that latest `main` revision, incorporating the already-merged Uhura #12 and #13 updates as requested; the root lockfile carries the corresponding `uhura-editor-model` dependency update.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `cargo test --locked --workspace --all-targets`
- `cargo run --locked -q -p spock-cli -- check examples/instagram/v0.spock`
- `cargo run --locked -q -p spock-cli -- check editors/vscode/test/corpus.spock`
- `cargo run --locked -q -p spock-cli -- check uhura/examples/instagram`
- `pnpm build` in `crates/spock-runtime/studio`
- `pnpm lint` in `crates/spock-runtime/studio` (passes with existing unrelated warnings)
- `git diff --check` in both repositories

- [x] I read and followed [CONTRIBUTING.md](https://github.com/gridaco/spock/blob/main/CONTRIBUTING.md).
- [x] I added or updated focused tests.
- [x] I updated user-facing documentation and included a prominently non-normative proposed specification patch.
- [x] I kept unrelated changes out of this PR.
- [ ] If this is experimental, I prominently marked it and kept it isolated from default behavior, the normative specification, and conformance expectations. This is intentionally unchecked: the branch prototype changes default compiler behavior and is therefore not for merge.
- [x] I have not presented a working-group study or community preference as an accepted language decision.